### PR TITLE
Add portal print templates and domain topology routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This repository contains an initial scaffold for a Kubernetes-native, multi-tena
 * [Operational runbooks and incident playbooks](docs/operations-runbooks.md)
 * [Operational dashboards and alert rules](docs/operations-dashboards-alerts.md)
 * [Kubernetes deployment notes](docs/kubernetes.md)
+* [Research LAB LIMS placeholder spec](docs/lab-lims.md)
+* [EDCS placeholder spec](docs/edcs.md)
 * [OpenAPI (HTTP surface)](docs/openapi.yaml)
 * [Eventing conventions](docs/events.md)
 
@@ -104,4 +106,45 @@ Note: Django creates a separate test database (e.g. `test_edmp_test`) during `py
 
 # broader local gate (docs checks + non-perf backend suite)
 .github/scripts/local_fast_feedback.sh --full-gate
+```
+
+### Local operations UI preview (django-material optional)
+
+```bash
+# one command local preview (services + migrations + tenant + runserver)
+./scripts/local_preview.sh up
+```
+
+HTML routes:
+* `/app` (end-user workspace)
+* `/ui/operations/dashboard`
+* `/ui/operations/stewardship`
+* `/ui/operations/orchestration`
+* `/ui/operations/printing`
+* `/ui/operations/agent`
+
+Printing UI supports:
+* printer (gateway) configuration
+* print template definition
+* template presets + inline preview for end users
+* test print submission from selected template
+* Zebra default batch mode: 9 labels per participant via prefix + range inputs
+* end-user workspace at `/app` for template/printer setup and test print
+* tenant service-route registry API: `GET/POST /api/v1/tenants/services` for wildcard hosts like `<service>.<tenant>.<base-domain>`
+* PDF preview download: `GET /api/v1/printing/jobs/<job_id>/preview.pdf`
+
+Useful subcommands:
+
+```bash
+./scripts/local_preview.sh prep    # dependencies + migrations + localhost tenant
+./scripts/local_preview.sh serve   # run Django server only
+./scripts/local_preview.sh status  # docker compose service status
+./scripts/local_preview.sh down    # stop local services
+```
+
+Optional:
+
+```bash
+EDMP_UI_MATERIAL_ENABLED=true ./scripts/local_preview.sh up
+EDMP_PREVIEW_PORT=8001 ./scripts/local_preview.sh up
 ```

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.0/ref/settings/
 """
 
+import importlib.util
 import os
 from pathlib import Path
 
@@ -44,6 +45,18 @@ SHARED_APPS = [
     'django.contrib.staticfiles',
     'tenants',
 ]
+
+EDMP_UI_MATERIAL_ENABLED = os.environ.get('EDMP_UI_MATERIAL_ENABLED', '').lower() in {
+    '1',
+    'true',
+    'yes',
+}
+if EDMP_UI_MATERIAL_ENABLED:
+    if importlib.util.find_spec('material') is None:
+        raise RuntimeError(
+            'EDMP_UI_MATERIAL_ENABLED is true but django-material is not installed'
+        )
+    SHARED_APPS.append('material')
 
 TENANT_APPS = [
     'core',

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -81,8 +81,10 @@ from core.views import (
     orchestration_runs,
     orchestration_workflows,
     print_job_detail,
+    print_job_preview_pdf,
     print_gateway_heartbeat,
     print_gateways,
+    print_templates,
     print_job_status,
     print_jobs,
     project_member_lifecycle,
@@ -127,11 +129,17 @@ from core.views import (
     workflow_run_transition,
     workflow_runs,
     ui_operations_agent_monitor,
+    ui_operations_agent_page,
     ui_operations_dashboard,
+    ui_operations_dashboard_page,
     ui_operations_orchestration_monitor,
+    ui_operations_orchestration_page,
+    ui_operations_printing_page,
     ui_operations_stewardship_workbench,
+    ui_operations_stewardship_page,
+    user_portal_dashboard_page,
 )
-from tenants.views import tenants
+from tenants.views import tenant_services, tenants
 
 urlpatterns = [
     path('', health, name='health'),
@@ -140,6 +148,7 @@ urlpatterns = [
     path('readyz', readyz, name='readyz'),
     path('metrics', metrics, name='metrics'),
     path('api/v1/tenants', tenants, name='tenants'),
+    path('api/v1/tenants/services', tenant_services, name='tenant_services'),
     path('api/v1/governance/policies', governance_policies, name='governance_policies'),
     path(
         'api/v1/governance/policies/<uuid:policy_id>',
@@ -220,8 +229,10 @@ urlpatterns = [
     path('api/v1/connectors/runs/<uuid:run_id>/cancel', connector_run_cancel, name='connector_run_cancel'),
     path('api/v1/printing/jobs', print_jobs, name='print_jobs'),
     path('api/v1/printing/jobs/<uuid:job_id>', print_job_detail, name='print_job_detail'),
+    path('api/v1/printing/jobs/<uuid:job_id>/preview.pdf', print_job_preview_pdf, name='print_job_preview_pdf'),
     path('api/v1/printing/jobs/<uuid:job_id>/status', print_job_status, name='print_job_status'),
     path('api/v1/printing/gateways', print_gateways, name='print_gateways'),
+    path('api/v1/printing/templates', print_templates, name='print_templates'),
     path(
         'api/v1/printing/gateways/<uuid:gateway_id>/heartbeat',
         print_gateway_heartbeat,
@@ -402,6 +413,20 @@ urlpatterns = [
         ui_operations_agent_monitor,
         name='ui_operations_agent_monitor',
     ),
+    path('ui/operations/dashboard', ui_operations_dashboard_page, name='ui_operations_dashboard_page'),
+    path(
+        'ui/operations/stewardship',
+        ui_operations_stewardship_page,
+        name='ui_operations_stewardship_page',
+    ),
+    path(
+        'ui/operations/orchestration',
+        ui_operations_orchestration_page,
+        name='ui_operations_orchestration_page',
+    ),
+    path('ui/operations/printing', ui_operations_printing_page, name='ui_operations_printing_page'),
+    path('ui/operations/agent', ui_operations_agent_page, name='ui_operations_agent_page'),
+    path('app', user_portal_dashboard_page, name='user_portal_dashboard_page'),
     path('api/v1/lineage/edges', lineage_edges, name='lineage_edges'),
     path('admin/', admin.site.urls),
 ]

--- a/backend/core/fixtures/printing_templates.json
+++ b/backend/core/fixtures/printing_templates.json
@@ -1,0 +1,50 @@
+[
+  {
+    "model": "core.printtemplate",
+    "pk": "b0f684f0-69f7-4b8e-95f4-b500e18fbab1",
+    "fields": {
+      "name": "Zebra QR Label (9-pack ready)",
+      "template_ref": "zebra/participant-batch",
+      "output_format": "zpl",
+      "content": "^XA^FO40,40^BQN,2,6^FDQA,[[label]]^FS^FO40,200^A0N,28,28^FD[[label]]^FS^XZ",
+      "sample_payload": {
+        "participant_prefix": "MLTP2-MBY-KWJ-",
+        "range_start": 1,
+        "range_end": 1,
+        "serial_position": "after_prefix",
+        "label_suffixes": [
+          "base",
+          "BLD-6mls",
+          "BLD-4mls",
+          "BLD-2mls",
+          "PLM1",
+          "PLM2",
+          "BLD-RNA",
+          "NA1",
+          "NA2"
+        ]
+      },
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    }
+  },
+  {
+    "model": "core.printtemplate",
+    "pk": "7b460fed-b28b-45b1-a70b-36860f70895e",
+    "fields": {
+      "name": "A4 QR Sheet 65-up (38.1x21.2mm)",
+      "template_ref": "a4/65-up",
+      "output_format": "pdf",
+      "content": "QR [[content]]",
+      "sample_payload": {
+        "labels": [
+          "MLTP2-MBY-KWJ-001"
+        ],
+        "pdf_sheet_preset": "a4-38x21.2",
+        "batch_count": 5
+      },
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-01-01T00:00:00Z"
+    }
+  }
+]

--- a/backend/core/migrations/0037_printtemplate.py
+++ b/backend/core/migrations/0037_printtemplate.py
@@ -1,0 +1,29 @@
+import uuid
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("core", "0036_printgateway"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PrintTemplate",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("name", models.CharField(max_length=200)),
+                ("template_ref", models.CharField(max_length=256, unique=True)),
+                ("output_format", models.CharField(choices=[("zpl", "Zpl"), ("pdf", "Pdf")], max_length=16)),
+                ("content", models.TextField(blank=True, default="")),
+                ("sample_payload", models.JSONField(blank=True, default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "indexes": [models.Index(fields=["-updated_at"], name="print_template_updated_idx")],
+            },
+        ),
+    ]

--- a/backend/core/models.py
+++ b/backend/core/models.py
@@ -712,6 +712,22 @@ class PrintGateway(models.Model):
         ]
 
 
+class PrintTemplate(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    name = models.CharField(max_length=200)
+    template_ref = models.CharField(max_length=256, unique=True)
+    output_format = models.CharField(max_length=16, choices=PrintJob.Format.choices)
+    content = models.TextField(blank=True, default="")
+    sample_payload = models.JSONField(default=dict, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        indexes = [
+            models.Index(fields=["-updated_at"], name="print_template_updated_idx"),
+        ]
+
+
 class CollaborationDocument(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     title = models.CharField(max_length=200)

--- a/backend/core/printing_renderers.py
+++ b/backend/core/printing_renderers.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import base64
+import io
+import re
+from typing import Any
+
+
+TOKEN_PATTERN = re.compile(r"\[\[\s*([a-zA-Z0-9_]+)\s*\]\]")
+MM_TO_PT = 72.0 / 25.4
+MAX_INLINE_PDF_LABELS = 120
+PDF_SHEET_PRESETS = {
+    'a4-38x21.2': {
+        'page_size_mm': (210.0, 297.0),
+        'label_size_mm': (38.1, 21.2),
+        'grid': (5, 13),  # 65-up
+        'gap_mm': (0.0, 0.0),
+    }
+}
+
+
+def _replace_tokens(text: str, payload: dict[str, Any]) -> str:
+    return TOKEN_PATTERN.sub(
+        lambda match: '' if payload.get(match.group(1)) is None else str(payload.get(match.group(1))),
+        text or '',
+    )
+
+
+def _normalize_labels(payload: dict[str, Any]) -> list[str]:
+    labels = payload.get('labels')
+    if isinstance(labels, list):
+        normalized = [str(item).strip() for item in labels if str(item).strip()]
+    else:
+        normalized = []
+    if not normalized:
+        single = str(payload.get('label') or payload.get('content') or '').strip()
+        if single:
+            normalized = [single]
+    return normalized
+
+
+def _zpl_qr_block(label: str) -> str:
+    return f"^XA^FO40,40^BQN,2,6^FDQA,{label}^FS^FO40,200^A0N,28,28^FD{label}^FS^XZ"
+
+
+def _normalize_pdf_sheet_preset(payload: dict[str, Any]) -> str:
+    value = str(payload.get('pdf_sheet_preset') or '').strip()
+    return value if value in PDF_SHEET_PRESETS else 'a4-38x21.2'
+
+
+def _expand_pdf_batch_labels(labels: list[str], payload: dict[str, Any]) -> tuple[list[str], int]:
+    batch_count = payload.get('batch_count')
+    if not isinstance(batch_count, int) or batch_count <= 1:
+        return labels, 1
+    expanded: list[str] = []
+    for item in labels:
+        expanded.extend([item] * batch_count)
+    return expanded, batch_count
+
+
+def _render_a4_pdf_sheet(labels: list[str], preset_key: str) -> tuple[str | None, str | None]:
+    try:
+        import qrcode
+        from reportlab.pdfgen import canvas
+    except ImportError as exc:
+        return None, f'missing_pdf_dependencies: {exc}'
+
+    preset = PDF_SHEET_PRESETS[preset_key]
+    page_w_mm, page_h_mm = preset['page_size_mm']
+    label_w_mm, label_h_mm = preset['label_size_mm']
+    cols, rows = preset.get('grid', (0, 0))
+    gap_x_mm, gap_y_mm = preset['gap_mm']
+
+    page_w_pt = page_w_mm * MM_TO_PT
+    page_h_pt = page_h_mm * MM_TO_PT
+    label_w_pt = label_w_mm * MM_TO_PT
+    label_h_pt = label_h_mm * MM_TO_PT
+    gap_x_pt = gap_x_mm * MM_TO_PT
+    gap_y_pt = gap_y_mm * MM_TO_PT
+
+    if not cols or not rows:
+        usable_w_pt = page_w_pt
+        usable_h_pt = page_h_pt
+        cols = max(1, int((usable_w_pt + gap_x_pt) // (label_w_pt + gap_x_pt)))
+        rows = max(1, int((usable_h_pt + gap_y_pt) // (label_h_pt + gap_y_pt)))
+    margin_x_pt = (page_w_pt - ((cols * label_w_pt) + ((cols - 1) * gap_x_pt))) / 2
+    margin_y_pt = (page_h_pt - ((rows * label_h_pt) + ((rows - 1) * gap_y_pt))) / 2
+    labels_per_page = rows * cols
+
+    pdf_buffer = io.BytesIO()
+    pdf = canvas.Canvas(pdf_buffer, pagesize=(page_w_pt, page_h_pt))
+    pdf.setFont('Helvetica', 7)
+
+    for index, label in enumerate(labels):
+        page_index = index % labels_per_page
+        if page_index == 0 and index > 0:
+            pdf.showPage()
+            pdf.setFont('Helvetica', 7)
+        row = page_index // cols
+        col = page_index % cols
+        x = margin_x_pt + (col * (label_w_pt + gap_x_pt))
+        y = page_h_pt - margin_y_pt - label_h_pt - (row * (label_h_pt + gap_y_pt))
+
+        qr = qrcode.QRCode(box_size=2, border=1)
+        qr.add_data(label)
+        qr.make(fit=True)
+        qr_img = qr.make_image(fill_color='black', back_color='white').get_image()
+        qr_size = min(label_h_pt * 0.58, label_w_pt * 0.54)
+        text = label[:48]
+        font_size = 7
+        max_text_width = label_w_pt - 4
+        while font_size > 5 and pdf.stringWidth(text, 'Helvetica', font_size) > max_text_width:
+            font_size -= 1
+        pdf.setFont('Helvetica', font_size)
+        text_width = pdf.stringWidth(text, 'Helvetica', font_size)
+        spacing = 2
+        group_height = qr_size + spacing + font_size
+        group_y = y + ((label_h_pt - group_height) / 2)
+        qr_x = x + ((label_w_pt - qr_size) / 2)
+        qr_y = group_y + font_size + spacing
+        text_x = x + ((label_w_pt - text_width) / 2)
+        text_y = group_y
+        pdf.drawInlineImage(qr_img, qr_x, qr_y, qr_size, qr_size)
+        pdf.drawString(text_x, text_y, text)
+
+    pdf.save()
+    encoded = base64.b64encode(pdf_buffer.getvalue()).decode('ascii')
+    return encoded, None
+
+
+def render_label_preview(*, output_format: str, template_content: str, payload: dict[str, Any]) -> dict[str, Any]:
+    labels = _normalize_labels(payload)
+    if output_format == 'zpl':
+        if labels:
+            if template_content:
+                rendered_blocks = []
+                for label in labels:
+                    rendered_blocks.append(
+                        _replace_tokens(template_content, {**payload, 'label': label, 'content': label})
+                    )
+                return {
+                    'engine': 'zpl-inline',
+                    'label_count': len(rendered_blocks),
+                    'rendered': '\n'.join(rendered_blocks),
+                }
+            return {
+                'engine': 'zpl-inline',
+                'label_count': len(labels),
+                'rendered': '\n'.join(_zpl_qr_block(label) for label in labels),
+            }
+        rendered = _replace_tokens(template_content, payload)
+        return {'engine': 'zpl-inline', 'label_count': 1, 'rendered': rendered}
+    if output_format == 'pdf':
+        preset_key = _normalize_pdf_sheet_preset(payload)
+        labels, batch_count = _expand_pdf_batch_labels(labels, payload)
+        preset = PDF_SHEET_PRESETS[preset_key]
+        if labels:
+            response = {
+                'engine': 'qrcode-reportlab-pylabels',
+                'sheet_preset': preset_key,
+                'label_count': len(labels),
+                'batch_count': batch_count,
+                'layout': {
+                    'grid': preset.get('grid'),
+                    'label_size_mm': preset.get('label_size_mm'),
+                    'page_size_mm': preset.get('page_size_mm'),
+                },
+            }
+            if len(labels) > MAX_INLINE_PDF_LABELS:
+                response['rendered'] = 'sheet payload too large for inline preview'
+                response['render_warning'] = (
+                    f'inline pdf disabled when labels>{MAX_INLINE_PDF_LABELS}'
+                )
+                return response
+            pdf_base64, render_error = _render_a4_pdf_sheet(labels, preset_key)
+            response['rendered'] = _replace_tokens(template_content, payload)
+            if pdf_base64:
+                response['pdf_base64'] = pdf_base64
+            if render_error:
+                response['render_error'] = render_error
+            return response
+        rendered = _replace_tokens(template_content, payload)
+        return {
+            'engine': 'qrcode-reportlab-pylabels',
+            'sheet_preset': preset_key,
+            'label_count': 1,
+            'batch_count': batch_count,
+            'layout': {
+                'grid': preset.get('grid'),
+                'label_size_mm': preset.get('label_size_mm'),
+                'page_size_mm': preset.get('page_size_mm'),
+            },
+            'rendered': rendered,
+        }
+    rendered = _replace_tokens(template_content, payload)
+    return {'engine': 'raw', 'rendered': rendered}

--- a/backend/core/templates/core/ui/base_fallback.html
+++ b/backend/core/templates/core/ui/base_fallback.html
@@ -1,0 +1,140 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}EDMP Operations{% endblock %}</title>
+    <style>
+      :root { color-scheme: light dark; }
+      body { margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f6f8fb; color: #111827; }
+      .skip-link { position: absolute; left: -9999px; top: 0; z-index: 1000; background: #2563eb; color: #fff; padding: 8px 12px; border-radius: 8px; }
+      .skip-link:focus { left: 16px; top: 12px; }
+      .layout { display: grid; grid-template-columns: 240px 1fr; min-height: 100vh; }
+      .sidebar { background: #111827; color: #e5e7eb; padding: 20px 16px; }
+      .brand { font-weight: 700; margin-bottom: 20px; }
+      .nav a { display: block; color: #cbd5e1; text-decoration: none; padding: 10px 12px; border-radius: 10px; margin-bottom: 6px; }
+      .nav a.active, .nav a:hover { background: #1f2937; color: #fff; }
+      .content { padding: 24px; }
+      .cards { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }
+      .card { background: #fff; border-radius: 12px; box-shadow: 0 1px 2px rgba(0,0,0,.06); padding: 14px; }
+      .toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 14px; }
+      .toolbar .right { display: flex; flex-wrap: wrap; gap: 8px; }
+      .input, .select { border: 1px solid #d1d5db; background: #fff; border-radius: 10px; padding: 8px 10px; font-size: 14px; }
+      .button { border: 1px solid #2563eb; color: #fff; background: #2563eb; border-radius: 10px; padding: 8px 12px; text-decoration: none; font-size: 14px; display: inline-block; }
+      .button.secondary { background: #fff; color: #2563eb; }
+      .chip { display: inline-block; border-radius: 999px; background: #e5e7eb; color: #374151; padding: 2px 8px; font-size: 12px; margin-right: 4px; }
+      .actions { display: flex; flex-wrap: wrap; gap: 6px; }
+      .banner { border-radius: 10px; padding: 10px 12px; margin-bottom: 14px; font-size: 14px; }
+      .banner.ok { background: #dcfce7; color: #166534; border: 1px solid #86efac; }
+      .banner.err { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+      .muted { color: #6b7280; }
+      table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 12px; overflow: hidden; }
+      th, td { padding: 10px 12px; border-bottom: 1px solid #e5e7eb; text-align: left; font-size: 14px; }
+      th { background: #f9fafb; font-weight: 600; }
+      a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible { outline: 3px solid #2563eb; outline-offset: 2px; }
+      @media (max-width: 920px) {
+        .layout { grid-template-columns: 1fr; }
+        .sidebar { padding: 12px; }
+        .nav { display: flex; flex-wrap: wrap; gap: 8px; }
+        .nav a { margin-bottom: 0; }
+        .toolbar { flex-direction: column; align-items: stretch; }
+      }
+    </style>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
+    <div class="layout">
+      <aside class="sidebar">
+        <div class="brand">EDMP Operations</div>
+        <nav class="nav" aria-label="Operations navigation">
+          <a href="/ui/operations/dashboard" class="{% if active_nav == 'dashboard' %}active{% endif %}">Dashboard</a>
+          <a href="/ui/operations/stewardship" class="{% if active_nav == 'stewardship' %}active{% endif %}">Stewardship</a>
+          <a href="/ui/operations/orchestration" class="{% if active_nav == 'orchestration' %}active{% endif %}">Orchestration</a>
+          <a href="/ui/operations/printing" class="{% if active_nav == 'printing' %}active{% endif %}">Printing</a>
+          <a href="/ui/operations/agent" class="{% if active_nav == 'agent' %}active{% endif %}">Agent runs</a>
+        </nav>
+      </aside>
+      <main class="content" id="main-content">
+        {% if ui_message %}
+          <div class="banner {% if ui_error %}err{% else %}ok{% endif %}">{{ ui_message }}</div>
+        {% endif %}
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+    <script>
+      async function edmpUiAction(url, payload) {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          let message = "Action failed";
+          try {
+            const data = await response.json();
+            message = data.error || message;
+          } catch (_e) {}
+          const current = new URL(window.location.href);
+          current.searchParams.set("ui_message", message);
+          current.searchParams.set("ui_error", "1");
+          window.location.assign(current.toString());
+          return;
+        }
+        const current = new URL(window.location.href);
+        current.searchParams.set("ui_message", "Action completed");
+        current.searchParams.set("ui_error", "0");
+        window.location.assign(current.toString());
+      }
+
+      function submitStewardshipAction(button, itemId) {
+        const root = button.closest('[data-ui-action-form="stewardship"]');
+        const action = root.querySelector('[data-field="action"]').value;
+        const assignee = root.querySelector('[data-field="assignee"]').value.trim();
+        const resolutionRaw = root.querySelector('[data-field="resolution"]').value.trim();
+        const payload = {action};
+        if (assignee) payload.assignee = assignee;
+        if (resolutionRaw) {
+          try {
+            payload.resolution = JSON.parse(resolutionRaw);
+          } catch (_e) {
+            const current = new URL(window.location.href);
+            current.searchParams.set("ui_message", "resolution must be valid JSON");
+            current.searchParams.set("ui_error", "1");
+            window.location.assign(current.toString());
+            return;
+          }
+        }
+        edmpUiAction(`/api/v1/stewardship/items/${itemId}/transition`, payload);
+      }
+
+      function submitOrchestrationAction(button, runId) {
+        const root = button.closest('[data-ui-action-form="orchestration"]');
+        const action = root.querySelector('[data-field="action"]').value;
+        edmpUiAction(`/api/v1/orchestration/runs/${runId}/transition`, {action});
+      }
+
+      function submitAgentAction(button, runId) {
+        const root = button.closest('[data-ui-action-form="agent"]');
+        const action = root.querySelector('[data-field="action"]').value;
+        const outputRaw = root.querySelector('[data-field="output"]').value.trim();
+        const errorMessage = root.querySelector('[data-field="error_message"]').value.trim();
+        const payload = {action};
+        if (action === "complete" && outputRaw) {
+          try {
+            payload.output = JSON.parse(outputRaw);
+          } catch (_e) {
+            const current = new URL(window.location.href);
+            current.searchParams.set("ui_message", "output must be valid JSON");
+            current.searchParams.set("ui_error", "1");
+            window.location.assign(current.toString());
+            return;
+          }
+        }
+        if (action === "fail" && errorMessage) {
+          payload.error_message = errorMessage;
+        }
+        edmpUiAction(`/api/v1/agent/runs/${runId}/transition`, payload);
+      }
+    </script>
+  </body>
+</html>

--- a/backend/core/templates/core/ui/operations_agent.html
+++ b/backend/core/templates/core/ui/operations_agent.html
@@ -1,0 +1,60 @@
+{% extends base_template %}
+{% block title %}Agent Monitor{% endblock %}
+{% block content %}
+<div class="toolbar">
+  <div>
+    <h1>Agent Monitor</h1>
+    <p class="muted">Recent agent runs and statuses.</p>
+  </div>
+  <form method="get" class="right" aria-label="Project filter">
+    <input class="input" type="text" name="project_id" placeholder="Project ID" value="{{ project_id }}">
+    <button class="button" type="submit">Filter</button>
+    <a class="button secondary" href="/ui/operations/agent">Clear</a>
+  </form>
+</div>
+<table>
+  <thead>
+    <tr>
+      <th>Prompt</th>
+      <th>Status</th>
+      <th>Timeout (s)</th>
+      <th>Updated</th>
+      <th>Run action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for run in payload.runs %}
+    <tr>
+      <td>{{ run.prompt|truncatechars:80 }}</td>
+      <td><span class="chip">{{ run.status }}</span></td>
+      <td>{{ run.timeout_seconds }}</td>
+      <td>{{ run.updated_at }}</td>
+      <td>
+        {% if run.allowed_actions %}
+        <div class="actions" data-ui-action-form="agent">
+          <select class="select" data-field="action" aria-label="Agent action">
+            {% for action in run.allowed_actions %}
+            <option value="{{ action }}">{{ action }}</option>
+            {% endfor %}
+          </select>
+          <input class="input" data-field="error_message" placeholder="error message (for fail)" aria-label="Error message">
+          <input class="input" data-field="output" placeholder='output JSON (for complete)' aria-label="Output JSON">
+          <button
+            class="button secondary"
+            data-ui-action="agent"
+            onclick="submitAgentAction(this, '{{ run.id }}')"
+          >
+            run
+          </button>
+        </div>
+        {% else %}
+        <span class="muted">No actions</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="5" class="muted">No agent runs</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/core/templates/core/ui/operations_dashboard.html
+++ b/backend/core/templates/core/ui/operations_dashboard.html
@@ -1,0 +1,56 @@
+{% extends base_template %}
+{% block title %}Operations Dashboard{% endblock %}
+{% block content %}
+<div class="toolbar">
+  <div>
+    <h1>Operations Dashboard</h1>
+    <p class="muted">Summary-first view with quick links into active work queues.</p>
+  </div>
+  <form method="get" class="right" aria-label="Project filter">
+    <input class="input" type="text" name="project_id" placeholder="Project ID" value="{{ project_id }}">
+    <button class="button" type="submit">Filter</button>
+    <a class="button secondary" href="/ui/operations/dashboard">Clear</a>
+  </form>
+</div>
+<div class="cards">
+  <div class="card">
+    <h3>Stewardship</h3>
+    {% for status, count in payload.cards.stewardship.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+    <p><a href="/ui/operations/stewardship">Open workbench →</a></p>
+  </div>
+  <div class="card">
+    <h3>Workflow</h3>
+    {% for status, count in payload.cards.workflow.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+  </div>
+  <div class="card">
+    <h3>Orchestration</h3>
+    {% for status, count in payload.cards.orchestration.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+    <p><a href="/ui/operations/orchestration">Open monitor →</a></p>
+  </div>
+  <div class="card">
+    <h3>Agents</h3>
+    {% for status, count in payload.cards.agent.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+    <p><a href="/ui/operations/agent">Open agent monitor →</a></p>
+  </div>
+  <div class="card">
+    <h3>Printing jobs</h3>
+    {% for status, count in payload.cards.printing.jobs.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+    <h3>Gateways</h3>
+    {% for status, count in payload.cards.printing.gateways.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+    <div><span class="chip">templates</span><strong>{{ payload.cards.printing.templates }}</strong></div>
+    <p><a href="/ui/operations/printing">Open printing monitor →</a></p>
+  </div>
+</div>
+{% endblock %}

--- a/backend/core/templates/core/ui/operations_orchestration.html
+++ b/backend/core/templates/core/ui/operations_orchestration.html
@@ -1,0 +1,51 @@
+{% extends base_template %}
+{% block title %}Orchestration Monitor{% endblock %}
+{% block content %}
+<div class="toolbar">
+  <div>
+    <h1>Orchestration Monitor</h1>
+    <p class="muted">Workflow catalog and run history.</p>
+  </div>
+  <form method="get" class="right" aria-label="Project filter">
+    <input class="input" type="text" name="project_id" placeholder="Project ID" value="{{ project_id }}">
+    <button class="button" type="submit">Filter</button>
+    <a class="button secondary" href="/ui/operations/orchestration">Clear</a>
+  </form>
+</div>
+<div class="cards">
+  <div class="card">
+    <h3>Workflows ({{ payload.workflows|length }})</h3>
+    {% for item in payload.workflows %}
+      <div>{{ item.name }} <span class="chip">{{ item.status }}</span></div>
+    {% empty %}
+      <div class="muted">No workflows</div>
+    {% endfor %}
+  </div>
+  <div class="card">
+    <h3>Runs ({{ payload.runs|length }})</h3>
+    {% for item in payload.runs %}
+      <div>
+        {{ item.id }} <span class="chip">{{ item.status }}</span>
+        {% if item.allowed_actions %}
+        <div class="actions" data-ui-action-form="orchestration">
+          <select class="select" data-field="action" aria-label="Orchestration action">
+            {% for action in item.allowed_actions %}
+            <option value="{{ action }}">{{ action }}</option>
+            {% endfor %}
+          </select>
+          <button
+            class="button secondary"
+            data-ui-action="orchestration"
+            onclick="submitOrchestrationAction(this, '{{ item.id }}')"
+          >
+            run
+          </button>
+        </div>
+        {% endif %}
+      </div>
+    {% empty %}
+      <div class="muted">No runs</div>
+    {% endfor %}
+  </div>
+</div>
+{% endblock %}

--- a/backend/core/templates/core/ui/operations_printing.html
+++ b/backend/core/templates/core/ui/operations_printing.html
@@ -1,0 +1,333 @@
+{% extends base_template %}
+{% block title %}Printing Operations{% endblock %}
+{% block content %}
+<div class="toolbar">
+  <div>
+    <h1>Printing Operations</h1>
+    <p class="muted">Configure printers, define templates, and run test prints.</p>
+  </div>
+  <form method="get" class="right" aria-label="Printing filters">
+    <select class="select" name="job_status">
+      <option value="">All job statuses</option>
+      {% for option in job_status_options %}
+      <option value="{{ option }}" {% if job_status_filter == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+    <select class="select" name="gateway_status">
+      <option value="">All gateway statuses</option>
+      {% for option in gateway_status_options %}
+      <option value="{{ option }}" {% if gateway_status_filter == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+    <button class="button" type="submit">Apply</button>
+    <a class="button secondary" href="/ui/operations/printing">Clear</a>
+  </form>
+</div>
+{{ payload.templates|json_script:"printing-templates-data" }}
+
+<div class="cards">
+  <div class="card">
+    <h3>Jobs</h3>
+    {% for status, count in payload.cards.jobs.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+  </div>
+  <div class="card">
+    <h3>Gateways</h3>
+    {% for status, count in payload.cards.gateways.items %}
+      <div><span class="chip">{{ status }}</span><strong>{{ count }}</strong></div>
+    {% endfor %}
+  </div>
+  <div class="card">
+    <h3>Templates</h3>
+    <div><span class="chip">count</span><strong>{{ payload.cards.templates }}</strong></div>
+  </div>
+</div>
+
+{% if payload.capabilities.can_manage_templates %}
+<div class="card" style="margin-top: 12px;">
+  <h3>Define print template</h3>
+  <div class="actions" data-ui-action-form="print-template-create">
+    <input class="input" data-field="name" placeholder="template name" aria-label="Template name">
+    <input class="input" data-field="template_ref" placeholder="template_ref" aria-label="Template ref">
+    <select class="select" data-field="output_format" aria-label="Template output format">
+      {% for option in job_format_options %}
+      <option value="{{ option }}">{{ option }}</option>
+      {% endfor %}
+    </select>
+    <input class="input" data-field="content" placeholder="template content" aria-label="Template content">
+    <input class="input" data-field="sample_payload" placeholder='sample payload JSON' aria-label="Sample payload JSON">
+    <button class="button secondary" data-ui-action="print-template-create" onclick="createPrintTemplate(this)">save</button>
+  </div>
+</div>
+{% endif %}
+
+{% if payload.capabilities.can_create_jobs %}
+<div class="card" style="margin-top: 12px;">
+  <h3>Run test print</h3>
+  <div class="actions" data-ui-action-form="print-job-test">
+    <select class="select" data-field="template_id" aria-label="Template">
+      <option value="">Select template</option>
+      {% for template in payload.templates %}
+      <option value="{{ template.id }}">{{ template.name }} ({{ template.template_ref }})</option>
+      {% endfor %}
+    </select>
+    <input class="input" data-field="destination" placeholder="destination" aria-label="Destination">
+    <input class="input" data-field="payload" placeholder='payload JSON (optional; defaults to template sample)' aria-label="Payload JSON">
+    <button class="button secondary" data-ui-action="print-job-test" onclick="createTestPrintJob(this)">test</button>
+  </div>
+</div>
+{% endif %}
+
+{% if payload.capabilities.can_manage_gateways %}
+<div class="card" style="margin-top: 12px;">
+  <h3>Configure printer</h3>
+  <div class="actions" data-ui-action-form="print-gateway-create">
+    <input class="input" data-field="gateway_ref" placeholder="printer_ref" aria-label="Printer ref">
+    <input class="input" data-field="display_name" placeholder="printer name" aria-label="Printer name">
+    <input class="input" data-field="site_ref" placeholder="site_ref (optional)" aria-label="Site ref">
+    <select class="select" data-field="status" aria-label="Gateway status">
+      {% for option in gateway_status_options %}
+      <option value="{{ option }}">{{ option }}</option>
+      {% endfor %}
+    </select>
+    <input class="input" data-field="capabilities" placeholder='capabilities JSON array (optional)' aria-label="Capabilities JSON">
+    <button class="button secondary" data-ui-action="print-gateway-create" onclick="createPrintGateway(this)">save</button>
+  </div>
+</div>
+{% endif %}
+
+<h3 style="margin-top: 16px;">Templates</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Ref</th>
+      <th>Format</th>
+      <th>Sample payload</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for template in payload.templates %}
+    <tr>
+      <td>{{ template.name }}</td>
+      <td>{{ template.template_ref }}</td>
+      <td><span class="chip">{{ template.output_format }}</span></td>
+      <td>{{ template.sample_payload }}</td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="4" class="muted">No print templates</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h3 style="margin-top: 16px;">Jobs</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Template</th>
+      <th>Destination</th>
+      <th>Format</th>
+      <th>Status</th>
+      <th>Retries</th>
+      <th>Run action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for job in payload.jobs %}
+    <tr>
+      <td>{{ job.template_ref }}</td>
+      <td>{{ job.destination }}</td>
+      <td>{{ job.output_format }}</td>
+      <td><span class="chip">{{ job.status }}</span></td>
+      <td>{{ job.retry_count }}</td>
+      <td>
+        {% if job.allowed_actions %}
+        <div class="actions" data-ui-action-form="print-job">
+          <select class="select" data-field="status" aria-label="Print job status action">
+            {% for action in job.allowed_actions %}
+            <option value="{{ action }}">{{ action }}</option>
+            {% endfor %}
+          </select>
+          <input class="input" data-field="retry_count" placeholder="retry_count (optional)" aria-label="Retry count">
+          <input class="input" data-field="error_message" placeholder="error message (for failed)" aria-label="Error message">
+          <input class="input" data-field="gateway_metadata" placeholder='gateway metadata JSON' aria-label="Gateway metadata JSON">
+          <button
+            class="button secondary"
+            data-ui-action="print-job"
+            onclick="submitPrintJobAction(this, '{{ job.id }}')"
+          >
+            run
+          </button>
+        </div>
+        {% else %}
+        <span class="muted">No actions</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="6" class="muted">No print jobs</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h3 style="margin-top: 16px;">Gateways</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Gateway</th>
+      <th>Ref</th>
+      <th>Status</th>
+      <th>Version</th>
+      <th>Last heartbeat</th>
+      <th>Run action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for gateway in payload.gateways %}
+    <tr>
+      <td>{{ gateway.display_name }}</td>
+      <td>{{ gateway.gateway_ref }}</td>
+      <td><span class="chip">{{ gateway.status }}</span></td>
+      <td>{{ gateway.last_seen_version|default_if_none:"" }}</td>
+      <td>{{ gateway.last_heartbeat_at|default_if_none:"" }}</td>
+      <td>
+        {% if payload.capabilities.can_manage_gateways %}
+        <div class="actions" data-ui-action-form="print-gateway">
+          <select class="select" data-field="status" aria-label="Gateway heartbeat status">
+            {% for option in gateway_status_options %}
+            <option value="{{ option }}" {% if gateway.status == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+          </select>
+          <input class="input" data-field="version" placeholder="version (optional)" aria-label="Gateway version">
+          <input class="input" data-field="capabilities" placeholder='capabilities JSON array' aria-label="Gateway capabilities JSON">
+          <input class="input" data-field="metadata" placeholder='metadata JSON object' aria-label="Gateway metadata JSON">
+          <button
+            class="button secondary"
+            data-ui-action="print-gateway"
+            onclick="submitPrintGatewayHeartbeat(this, '{{ gateway.id }}')"
+          >
+            heartbeat
+          </button>
+        </div>
+        {% else %}
+        <span class="muted">No actions</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="6" class="muted">No gateways</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<script>
+  function parseJsonOrError(raw, fallback, errorMessage) {
+    if (!raw.trim()) return fallback;
+    try {
+      return JSON.parse(raw);
+    } catch (_e) {
+      const current = new URL(window.location.href);
+      current.searchParams.set("ui_message", errorMessage);
+      current.searchParams.set("ui_error", "1");
+      window.location.assign(current.toString());
+      return null;
+    }
+  }
+  const printTemplates = JSON.parse(document.getElementById("printing-templates-data").textContent);
+
+  function setUiError(message) {
+    const current = new URL(window.location.href);
+    current.searchParams.set("ui_message", message);
+    current.searchParams.set("ui_error", "1");
+    window.location.assign(current.toString());
+  }
+
+  function submitPrintJobAction(button, jobId) {
+    const root = button.closest('[data-ui-action-form="print-job"]');
+    const payload = {status: root.querySelector('[data-field="status"]').value};
+    const retryRaw = root.querySelector('[data-field="retry_count"]').value.trim();
+    if (retryRaw) payload.retry_count = Number.parseInt(retryRaw, 10);
+    const errorMessage = root.querySelector('[data-field="error_message"]').value.trim();
+    if (errorMessage) payload.error_message = errorMessage;
+    const metadataRaw = root.querySelector('[data-field="gateway_metadata"]').value;
+    const parsedMetadata = parseJsonOrError(metadataRaw, undefined, "gateway_metadata must be valid JSON");
+    if (parsedMetadata === null) return;
+    if (parsedMetadata !== undefined) payload.gateway_metadata = parsedMetadata;
+    edmpUiAction(`/api/v1/printing/jobs/${jobId}/status`, payload);
+  }
+
+  function submitPrintGatewayHeartbeat(button, gatewayId) {
+    const root = button.closest('[data-ui-action-form="print-gateway"]');
+    const payload = {status: root.querySelector('[data-field="status"]').value};
+    const version = root.querySelector('[data-field="version"]').value.trim();
+    if (version) payload.version = version;
+    const capabilitiesRaw = root.querySelector('[data-field="capabilities"]').value;
+    const parsedCapabilities = parseJsonOrError(capabilitiesRaw, undefined, "capabilities must be valid JSON array");
+    if (parsedCapabilities === null) return;
+    if (parsedCapabilities !== undefined) payload.capabilities = parsedCapabilities;
+    const metadataRaw = root.querySelector('[data-field="metadata"]').value;
+    const parsedMetadata = parseJsonOrError(metadataRaw, undefined, "metadata must be valid JSON object");
+    if (parsedMetadata === null) return;
+    if (parsedMetadata !== undefined) payload.metadata = parsedMetadata;
+    edmpUiAction(`/api/v1/printing/gateways/${gatewayId}/heartbeat`, payload);
+  }
+
+  function createPrintTemplate(button) {
+    const root = button.closest('[data-ui-action-form="print-template-create"]');
+    const samplePayloadRaw = root.querySelector('[data-field="sample_payload"]').value;
+    const samplePayload = parseJsonOrError(samplePayloadRaw, {}, "sample_payload must be valid JSON object");
+    if (samplePayload === null) return;
+    edmpUiAction('/api/v1/printing/templates', {
+      name: root.querySelector('[data-field="name"]').value.trim(),
+      template_ref: root.querySelector('[data-field="template_ref"]').value.trim(),
+      output_format: root.querySelector('[data-field="output_format"]').value,
+      content: root.querySelector('[data-field="content"]').value.trim(),
+      sample_payload: samplePayload,
+    });
+  }
+
+  function createTestPrintJob(button) {
+    const root = button.closest('[data-ui-action-form="print-job-test"]');
+    const selectedTemplateId = root.querySelector('[data-field="template_id"]').value;
+    const template = printTemplates.find((item) => item.id === selectedTemplateId);
+    if (!template) {
+      setUiError("Select a template first");
+      return;
+    }
+    const destination = root.querySelector('[data-field="destination"]').value.trim();
+    if (!destination) {
+      setUiError("destination is required");
+      return;
+    }
+    const payloadRaw = root.querySelector('[data-field="payload"]').value;
+    const parsedPayload = parseJsonOrError(payloadRaw, template.sample_payload || {}, "payload must be valid JSON object");
+    if (parsedPayload === null) return;
+    edmpUiAction('/api/v1/printing/jobs', {
+      template_ref: template.template_ref,
+      destination: destination,
+      output_format: template.output_format,
+      payload: parsedPayload,
+    });
+  }
+
+  function createPrintGateway(button) {
+    const root = button.closest('[data-ui-action-form="print-gateway-create"]');
+    const capabilitiesRaw = root.querySelector('[data-field="capabilities"]').value;
+    const parsedCapabilities = parseJsonOrError(capabilitiesRaw, [], "capabilities must be valid JSON array");
+    if (parsedCapabilities === null) return;
+    if (!Array.isArray(parsedCapabilities)) {
+      setUiError("capabilities must be a JSON array");
+      return;
+    }
+    const payload = {
+      gateway_ref: root.querySelector('[data-field="gateway_ref"]').value.trim(),
+      display_name: root.querySelector('[data-field="display_name"]').value.trim(),
+      site_ref: root.querySelector('[data-field="site_ref"]').value.trim(),
+      status: root.querySelector('[data-field="status"]').value,
+      capabilities: parsedCapabilities,
+    };
+    edmpUiAction('/api/v1/printing/gateways', payload);
+  }
+</script>
+{% endblock %}

--- a/backend/core/templates/core/ui/operations_stewardship.html
+++ b/backend/core/templates/core/ui/operations_stewardship.html
@@ -1,0 +1,75 @@
+{% extends base_template %}
+{% block title %}Stewardship Workbench{% endblock %}
+{% block content %}
+<div class="toolbar">
+  <div>
+    <h1>Stewardship Workbench</h1>
+    <p class="muted">Queue view with action affordances from API `allowed_actions`.</p>
+  </div>
+  <form method="get" class="right" aria-label="Stewardship filters">
+    <select class="select" name="status">
+      <option value="">All statuses</option>
+      {% for option in status_options %}
+      <option value="{{ option }}" {% if status_filter == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+    <select class="select" name="severity">
+      <option value="">All severities</option>
+      {% for option in severity_options %}
+      <option value="{{ option }}" {% if severity_filter == option %}selected{% endif %}>{{ option }}</option>
+      {% endfor %}
+    </select>
+    <button class="button" type="submit">Apply</button>
+    <a class="button secondary" href="/ui/operations/stewardship">Clear</a>
+  </form>
+</div>
+<table>
+  <thead>
+    <tr>
+      <th>Subject</th>
+      <th>Status</th>
+      <th>Severity</th>
+      <th>Allowed actions</th>
+      <th>Run action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in payload.items %}
+    <tr>
+      <td>{{ item.subject_ref }}</td>
+      <td><span class="chip">{{ item.status }}</span></td>
+      <td><span class="chip">{{ item.severity }}</span></td>
+      <td class="actions">
+        {% for action in item.allowed_actions %}
+        <span class="chip">{{ action }}</span>
+        {% endfor %}
+      </td>
+      <td>
+        {% if payload.capabilities.can_manage_stewardship and item.allowed_actions %}
+          <div data-ui-action-form="stewardship" class="actions">
+            <select class="select" data-field="action" aria-label="Action">
+              {% for action in item.allowed_actions %}
+              <option value="{{ action }}">{{ action }}</option>
+              {% endfor %}
+            </select>
+            <input class="input" data-field="assignee" placeholder="assignee (for assign)" aria-label="Assignee">
+            <input class="input" data-field="resolution" placeholder='resolution JSON (for resolve)' aria-label="Resolution JSON">
+            <button
+              class="button secondary"
+              data-ui-action="stewardship"
+              onclick="submitStewardshipAction(this, '{{ item.id }}')"
+            >
+              run
+            </button>
+          </div>
+        {% else %}
+          <span class="muted">No actions</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="5" class="muted">No stewardship items</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/backend/core/templates/core/ui/user_base.html
+++ b/backend/core/templates/core/ui/user_base.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}EDMP Workspace{% endblock %}</title>
+    <style>
+      body { margin: 0; font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background: #f6f8fb; color: #111827; }
+      .layout { display: grid; grid-template-columns: 220px 1fr; min-height: 100vh; }
+      .sidebar { background: #0f172a; color: #e2e8f0; padding: 20px 14px; }
+      .brand { font-weight: 700; margin-bottom: 18px; }
+      .nav a { display: block; color: #cbd5e1; text-decoration: none; padding: 10px 12px; border-radius: 10px; margin-bottom: 6px; }
+      .nav a.active, .nav a:hover { background: #1e293b; color: #fff; }
+      .content { padding: 24px; }
+      .cards { display: grid; gap: 12px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); margin-bottom: 12px; }
+      .card { background: #fff; border-radius: 12px; box-shadow: 0 1px 2px rgba(0,0,0,.06); padding: 14px; }
+      .actions { display: flex; flex-wrap: wrap; gap: 8px; }
+      .form-rows { display: flex; flex-direction: column; gap: 8px; max-width: 640px; }
+      .form-row { display: block; }
+      .form-row .input, .form-row .select, .form-row .button { width: 100%; box-sizing: border-box; }
+      .input, .select { border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px; font-size: 14px; background: #fff; }
+      .button { border: 1px solid #2563eb; color: #fff; background: #2563eb; border-radius: 10px; padding: 8px 12px; font-size: 14px; }
+      .chip { display: inline-block; border-radius: 999px; background: #e2e8f0; color: #334155; padding: 2px 8px; font-size: 12px; }
+      .muted { color: #64748b; }
+      table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 12px; overflow: hidden; }
+      th, td { padding: 10px 12px; border-bottom: 1px solid #e2e8f0; text-align: left; font-size: 14px; }
+      th { background: #f8fafc; font-weight: 600; }
+      .banner { border-radius: 10px; padding: 10px 12px; margin-bottom: 14px; font-size: 14px; }
+      .banner.ok { background: #dcfce7; color: #166534; border: 1px solid #86efac; }
+      .banner.err { background: #fee2e2; color: #991b1b; border: 1px solid #fca5a5; }
+      @media (max-width: 920px) { .layout { grid-template-columns: 1fr; } }
+    </style>
+  </head>
+  <body>
+    <div class="layout">
+      <aside class="sidebar">
+        <div class="brand">EDMP Workspace</div>
+        <nav class="nav" aria-label="Workspace navigation">
+          <a href="/app" class="{% if active_nav == 'home' %}active{% endif %}">Home</a>
+          {% if payload.navigation.can_view_operations %}
+          <a href="/ui/operations/printing">Operations printing</a>
+          {% endif %}
+        </nav>
+      </aside>
+      <main class="content">
+        <div class="card" style="margin-bottom: 12px;">
+          <div><strong>Signed in as:</strong> {{ payload.user_context.user_id }}</div>
+          <div><strong>Tenant:</strong> {{ payload.user_context.tenant_schema }}</div>
+          <div>
+            <strong>Roles:</strong>
+            {% if payload.user_context.roles %}
+              {% for role in payload.user_context.roles %}
+              <span class="chip">{{ role }}</span>
+              {% endfor %}
+            {% else %}
+              <span class="muted">none</span>
+            {% endif %}
+          </div>
+        </div>
+        {% if ui_message %}
+          <div class="banner {% if ui_error %}err{% else %}ok{% endif %}">{{ ui_message }}</div>
+        {% endif %}
+        {% block content %}{% endblock %}
+      </main>
+    </div>
+    <script>
+      async function edmpPortalAction(url, payload) {
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {"Content-Type": "application/json"},
+          body: JSON.stringify(payload),
+        });
+        const current = new URL(window.location.href);
+        if (!response.ok) {
+          let message = "Action failed";
+          try {
+            const data = await response.json();
+            message = data.error || message;
+          } catch (_e) {}
+          current.searchParams.set("ui_message", message);
+          current.searchParams.set("ui_error", "1");
+          window.location.assign(current.toString());
+          return;
+        }
+        current.searchParams.set("ui_message", "Action completed");
+        current.searchParams.set("ui_error", "0");
+        window.location.assign(current.toString());
+      }
+    </script>
+  </body>
+</html>

--- a/backend/core/templates/core/ui/user_dashboard.html
+++ b/backend/core/templates/core/ui/user_dashboard.html
@@ -1,0 +1,338 @@
+{% extends "core/ui/user_base.html" %}
+{% block title %}User Workspace{% endblock %}
+{% block content %}
+<h1>User Workspace</h1>
+<p class="muted">Use templates and configured printers to submit a test print.</p>
+
+<div class="cards">
+  <div class="card"><span class="chip">Templates</span> <strong>{{ payload.cards.templates }}</strong></div>
+  <div class="card"><span class="chip">Printers</span> <strong>{{ payload.cards.printers }}</strong></div>
+  <div class="card"><span class="chip">Recent jobs</span> <strong>{{ payload.cards.recent_jobs }}</strong></div>
+</div>
+
+<div class="card">
+  <h3>Test print</h3>
+  {% if payload.capabilities.can_submit_print_jobs %}
+  {{ payload.templates|json_script:"user-print-templates-data" }}
+  <div class="form-rows" data-user-action-form="test-print">
+    <div class="form-row"><select class="select" data-field="template_id" aria-label="Template">
+      <option value="">Select template</option>
+      {% for template in payload.templates %}
+      <option value="{{ template.id }}">{{ template.name }} ({{ template.output_format }})</option>
+      {% endfor %}
+    </select></div>
+    <div class="form-row"><select class="select" data-field="destination" aria-label="Printer destination">
+      <option value="">Select printer</option>
+      {% for gateway in payload.gateways %}
+      <option value="{{ gateway.gateway_ref }}">{{ gateway.display_name }} ({{ gateway.gateway_ref }})</option>
+      {% endfor %}
+    </select></div>
+    <div class="form-row"><input class="input" data-field="participant_prefix" placeholder="participant prefix (e.g. MLTP2-MBY-KWJ-)" aria-label="Participant prefix"></div>
+    <div class="form-row"><input class="input" data-field="range_start" placeholder="range start (e.g. 001)" aria-label="Range start"></div>
+    <div class="form-row"><input class="input" data-field="range_end" placeholder="range end (e.g. 100)" aria-label="Range end"></div>
+    <div class="form-row"><select class="select" data-field="serial_position" aria-label="Serial position">
+      <option value="after_prefix">Serial after prefix (default)</option>
+      <option value="at_end">Serial at end</option>
+    </select></div>
+    <div class="form-row"><input class="input" data-field="label_suffixes" placeholder="label variants (comma-separated, use base for root)" aria-label="Label variants"></div>
+    <div class="form-row"><select class="select" data-field="pdf_sheet_preset" aria-label="PDF sheet preset">
+      <option value="a4-38x21.2">A4 38x21.2mm labels</option>
+    </select></div>
+    <div class="form-row"><input class="input" data-field="batch_count" placeholder="PDF row batch count (e.g. 5)" aria-label="PDF row batch count"></div>
+    <div class="form-row"><textarea class="input" data-field="labels_input" placeholder="labels (optional, one per line)" aria-label="Labels list" style="min-height:96px;"></textarea></div>
+    <div class="form-row"><input class="input" data-field="payload" placeholder='payload JSON (optional)' aria-label="Payload JSON"></div>
+    <div class="form-row"><button class="button" data-user-action="test-print" onclick="submitUserTestPrint(this)">Print</button></div>
+  </div>
+  <div class="muted" style="margin-top:6px;">Default batch: 9 Zebra labels per participant. For A4 PDF, set row batch count (e.g. 5) to repeat each label across a full row.</div>
+  {% else %}
+  <div class="muted">No print permissions for this account.</div>
+  {% endif %}
+</div>
+
+{% if payload.capabilities.can_manage_templates %}
+<div class="card" style="margin-top: 12px;">
+  <h3>Template designer</h3>
+  <div class="form-rows" data-user-action-form="create-template">
+    <div class="form-row"><select class="select" data-field="preset" aria-label="Template preset">
+      <option value="">Preset (optional)</option>
+      <option value="zebra-qr">Zebra QR label</option>
+      <option value="a4-qr-38x21-2">A4 QR sheet 38x21.2mm</option>
+    </select></div>
+    <div class="form-row"><input class="input" data-field="name" placeholder="Template name" aria-label="Template name"></div>
+    <div class="form-row"><input class="input" data-field="template_ref" placeholder="template_ref" aria-label="Template ref"></div>
+    <div class="form-row"><select class="select" data-field="output_format" aria-label="Template format">
+      <option value="pdf">pdf</option>
+      <option value="zpl">zpl</option>
+    </select></div>
+    <div class="form-row"><input class="input" data-field="content" placeholder="Template content (supports [[variable]])" aria-label="Template content"></div>
+    <div class="form-row"><input class="input" data-field="sample_payload" placeholder='sample payload JSON (optional)' aria-label="Sample payload JSON"></div>
+    <div class="form-row"><button class="button" data-user-action="template-preview" onclick="previewUserTemplate(this)">Preview</button></div>
+    <div class="form-row"><button class="button" data-user-action="create-template" onclick="createUserTemplate(this)">Create</button></div>
+  </div>
+  <pre class="muted" data-field="preview-output" style="margin-top:8px;white-space:pre-wrap"></pre>
+</div>
+{% endif %}
+
+{% if payload.capabilities.can_manage_printers %}
+<div class="card" style="margin-top: 12px;">
+  <h3>Printer profiles</h3>
+  <div class="form-rows" data-user-action-form="create-printer">
+    <div class="form-row"><input class="input" data-field="display_name" placeholder="Printer name" aria-label="Printer name"></div>
+    <div class="form-row"><input class="input" data-field="gateway_ref" placeholder="printer_ref" aria-label="Printer ref"></div>
+    <div class="form-row"><input class="input" data-field="site_ref" placeholder="Site (optional)" aria-label="Site"></div>
+    <div class="form-row"><select class="select" data-field="status" aria-label="Printer status">
+      <option value="online">online</option>
+      <option value="offline">offline</option>
+      <option value="degraded">degraded</option>
+    </select></div>
+    <div class="form-row"><button class="button" data-user-action="create-printer" onclick="createUserPrinter(this)">Add</button></div>
+  </div>
+  <table style="margin-top: 10px;">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Ref</th>
+        <th>Status</th>
+        <th>Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for gateway in payload.gateways %}
+      <tr>
+        <td>{{ gateway.display_name }}</td>
+        <td>{{ gateway.gateway_ref }}</td>
+        <td><span class="chip">{{ gateway.status }}</span></td>
+        <td>
+          <div class="form-rows" data-user-action-form="update-printer-status">
+            <div class="form-row"><select class="select" data-field="status" aria-label="Printer status action">
+              <option value="online" {% if gateway.status == 'online' %}selected{% endif %}>online</option>
+              <option value="offline" {% if gateway.status == 'offline' %}selected{% endif %}>offline</option>
+              <option value="degraded" {% if gateway.status == 'degraded' %}selected{% endif %}>degraded</option>
+            </select></div>
+            <div class="form-row"><button class="button" data-user-action="printer-status-update" onclick="updateUserPrinterStatus(this, '{{ gateway.id }}')">Save</button></div>
+          </div>
+        </td>
+      </tr>
+      {% empty %}
+      <tr><td colspan="4" class="muted">No printers configured</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+<h3 style="margin-top: 16px;">Recent print jobs</h3>
+<table>
+  <thead>
+    <tr>
+      <th>Template</th>
+      <th>Destination</th>
+      <th>Status</th>
+      <th>Updated</th>
+      <th>Preview</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in payload.recent_jobs %}
+    <tr>
+      <td>{{ item.template_ref }}</td>
+      <td>{{ item.destination }}</td>
+      <td><span class="chip">{{ item.status }}</span></td>
+      <td>{{ item.updated_at }}</td>
+      <td>
+        {% if item.output_format == "pdf" %}
+        <a href="/api/v1/printing/jobs/{{ item.id }}/preview.pdf">Download PDF</a>
+        {% else %}
+        <span class="muted">n/a</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="5" class="muted">No print jobs yet</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<script>
+  function userUiError(message) {
+    const current = new URL(window.location.href);
+    current.searchParams.set("ui_message", message);
+    current.searchParams.set("ui_error", "1");
+    window.location.assign(current.toString());
+  }
+
+  function parseUserJson(raw, fallback, fieldName) {
+    if (!raw.trim()) return fallback;
+    try {
+      return JSON.parse(raw);
+    } catch (_e) {
+      userUiError(`${fieldName} must be valid JSON`);
+      return null;
+    }
+  }
+
+  function applySelectedPrintTemplate(select) {
+    const templates = JSON.parse(document.getElementById("user-print-templates-data").textContent);
+    const root = select.closest('[data-user-action-form="test-print"]');
+    const selected = templates.find((item) => item.id === select.value);
+    if (!selected) return;
+    const sample = selected.sample_payload || {};
+    root.querySelector('[data-field="payload"]').value = JSON.stringify(sample);
+    root.querySelector('[data-field="participant_prefix"]').value = sample.participant_prefix || "";
+    root.querySelector('[data-field="range_start"]').value = sample.range_start || "";
+    root.querySelector('[data-field="range_end"]').value = sample.range_end || "";
+    root.querySelector('[data-field="serial_position"]').value = sample.serial_position || "after_prefix";
+    root.querySelector('[data-field="label_suffixes"]').value = Array.isArray(sample.label_suffixes)
+      ? sample.label_suffixes.join(",")
+      : "";
+    root.querySelector('[data-field="pdf_sheet_preset"]').value = sample.pdf_sheet_preset || "a4-38x21.2";
+    root.querySelector('[data-field="batch_count"]').value = sample.batch_count || "";
+    root.querySelector('[data-field="labels_input"]').value = Array.isArray(sample.labels)
+      ? sample.labels.join("\n")
+      : "";
+  }
+
+  function submitUserTestPrint(button) {
+    const templates = JSON.parse(document.getElementById("user-print-templates-data").textContent);
+    const root = button.closest('[data-user-action-form="test-print"]');
+    const templateId = root.querySelector('[data-field="template_id"]').value;
+    const destination = root.querySelector('[data-field="destination"]').value.trim();
+    const participantPrefix = root.querySelector('[data-field="participant_prefix"]').value.trim();
+    const rangeStartRaw = root.querySelector('[data-field="range_start"]').value.trim();
+    const rangeEndRaw = root.querySelector('[data-field="range_end"]').value.trim();
+    const serialPosition = root.querySelector('[data-field="serial_position"]').value;
+    const suffixesRaw = root.querySelector('[data-field="label_suffixes"]').value.trim();
+    const pdfSheetPreset = root.querySelector('[data-field="pdf_sheet_preset"]').value;
+    const batchCountRaw = root.querySelector('[data-field="batch_count"]').value.trim();
+    const labelsInputRaw = root.querySelector('[data-field="labels_input"]').value.trim();
+    const payloadRaw = root.querySelector('[data-field="payload"]').value.trim();
+    const selected = templates.find((item) => item.id === templateId);
+    if (!selected || !destination) {
+      userUiError("template and destination are required");
+      return;
+    }
+    let payload = selected.sample_payload || {};
+    if (payloadRaw) {
+      try {
+        payload = JSON.parse(payloadRaw);
+      } catch (_e) {
+        userUiError("payload must be valid JSON");
+        return;
+      }
+    }
+    if (selected.output_format === "zpl" && participantPrefix && rangeStartRaw && rangeEndRaw) {
+      const rangeStart = Number.parseInt(rangeStartRaw, 10);
+      const rangeEnd = Number.parseInt(rangeEndRaw, 10);
+      if (Number.isNaN(rangeStart) || Number.isNaN(rangeEnd) || rangeStart <= 0 || rangeEnd < rangeStart) {
+        userUiError("invalid participant range");
+        return;
+      }
+      payload = {
+        ...payload,
+        participant_prefix: participantPrefix,
+        range_start: rangeStart,
+        range_end: rangeEnd,
+        serial_position: serialPosition,
+      };
+      if (suffixesRaw) {
+        payload.label_suffixes = suffixesRaw.split(',').map((item) => item.trim()).filter(Boolean);
+      }
+    }
+    if (labelsInputRaw) {
+      payload.labels = labelsInputRaw.split(/\r?\n/).map((item) => item.trim()).filter(Boolean);
+    }
+    if (selected.output_format === "pdf") {
+      payload.pdf_sheet_preset = pdfSheetPreset;
+      if (batchCountRaw) {
+        const batchCount = Number.parseInt(batchCountRaw, 10);
+        if (Number.isNaN(batchCount) || batchCount <= 0) {
+          userUiError("pdf row batch count must be a positive integer");
+          return;
+        }
+        payload.batch_count = batchCount;
+      }
+    }
+    edmpPortalAction("/api/v1/printing/jobs", {
+      template_ref: selected.template_ref,
+      output_format: selected.output_format,
+      destination: destination,
+      payload: payload,
+    });
+  }
+
+  function createUserTemplate(button) {
+    const root = button.closest('[data-user-action-form="create-template"]');
+    const samplePayloadRaw = root.querySelector('[data-field="sample_payload"]').value;
+    const samplePayload = parseUserJson(samplePayloadRaw, {}, "sample_payload");
+    if (samplePayload === null) return;
+    edmpPortalAction("/api/v1/printing/templates", {
+      name: root.querySelector('[data-field="name"]').value.trim(),
+      template_ref: root.querySelector('[data-field="template_ref"]').value.trim(),
+      output_format: root.querySelector('[data-field="output_format"]').value,
+      content: root.querySelector('[data-field="content"]').value.trim(),
+      sample_payload: samplePayload,
+    });
+  }
+
+  function previewUserTemplate(button) {
+    const root = button.closest('[data-user-action-form="create-template"]');
+    const content = root.querySelector('[data-field="content"]').value || "";
+    const samplePayloadRaw = root.querySelector('[data-field="sample_payload"]').value;
+    const samplePayload = parseUserJson(samplePayloadRaw, {}, "sample_payload");
+    if (samplePayload === null) return;
+    const preview = content.replace(/\[\[\s*([a-zA-Z0-9_]+)\s*\]\]/g, (_m, key) => {
+      const value = samplePayload[key];
+      return value === undefined || value === null ? "" : String(value);
+    });
+    root.parentElement.querySelector('[data-field="preview-output"]').textContent = preview || "(empty preview)";
+  }
+
+  function createUserPrinter(button) {
+    const root = button.closest('[data-user-action-form="create-printer"]');
+    edmpPortalAction("/api/v1/printing/gateways", {
+      display_name: root.querySelector('[data-field="display_name"]').value.trim(),
+      gateway_ref: root.querySelector('[data-field="gateway_ref"]').value.trim(),
+      site_ref: root.querySelector('[data-field="site_ref"]').value.trim(),
+      status: root.querySelector('[data-field="status"]').value,
+    });
+  }
+
+  function updateUserPrinterStatus(button, gatewayId) {
+    const root = button.closest('[data-user-action-form="update-printer-status"]');
+    edmpPortalAction(`/api/v1/printing/gateways/${gatewayId}/heartbeat`, {
+      status: root.querySelector('[data-field="status"]').value,
+    });
+  }
+
+  function applyTemplatePreset(select) {
+    const root = select.closest('[data-user-action-form="create-template"]');
+    const preset = select.value;
+    if (preset === "zebra-qr") {
+      root.querySelector('[data-field="name"]').value = "Zebra QR Label";
+      root.querySelector('[data-field="template_ref"]').value = "zebra/qr-default";
+      root.querySelector('[data-field="output_format"]').value = "zpl";
+      root.querySelector('[data-field="content"]').value = "^XA^FO40,40^BQN,2,6^FDQA,[[content]]^FS^XZ";
+      root.querySelector('[data-field="sample_payload"]').value = JSON.stringify({"content":"SAMPLE-001"});
+      const testRoot = document.querySelector('[data-user-action-form="test-print"]');
+      if (testRoot) {
+        testRoot.querySelector('[data-field="label_suffixes"]').value = "base,BLD-6mls,BLD-4mls,BLD-2mls,PLM1,PLM2,BLD-RNA,NA1,NA2";
+      }
+      return;
+    }
+    if (preset === "a4-qr-38x21-2") {
+      root.querySelector('[data-field="name"]').value = "A4 QR 38x21.2mm";
+      root.querySelector('[data-field="template_ref"]').value = "a4/qr-38x21-2";
+      root.querySelector('[data-field="output_format"]').value = "pdf";
+      root.querySelector('[data-field="content"]').value = "QR: [[content]]";
+      root.querySelector('[data-field="sample_payload"]').value = JSON.stringify({"content":"SAMPLE-001"});
+    }
+  }
+
+  document.querySelectorAll('[data-field="preset"]').forEach((item) => {
+    item.addEventListener("change", () => applyTemplatePreset(item));
+  });
+  document.querySelectorAll('[data-user-action-form="test-print"] [data-field="template_id"]').forEach((item) => {
+    item.addEventListener("change", () => applySelectedPrintTemplate(item));
+  });
+</script>
+{% endblock %}

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import hashlib
 import json
 import os
@@ -6,11 +8,15 @@ import uuid
 from datetime import timedelta
 from typing import Any
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import connection
 from django.db.models import Max, Q
 from django.db.utils import DatabaseError
 from django.http import HttpResponse, JsonResponse
+from django.shortcuts import render
+from django.template import TemplateDoesNotExist
+from django.template.loader import get_template
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
@@ -47,6 +53,7 @@ from .models import (
     PrivacyProfile,
     PrintJob,
     PrintGateway,
+    PrintTemplate,
     Project,
     ProjectInvitation,
     ProjectMembership,
@@ -68,7 +75,46 @@ from .models import (
     WorkflowTask,
 )
 from .notifications import dispatch_notification, process_notification_queue
+from .printing_renderers import render_label_preview
 from .tasks import evaluate_quality_rule, execute_connector_run, execute_retention_run
+
+
+DEFAULT_PRINT_TEMPLATE_DEFINITIONS: tuple[dict[str, Any], ...] = (
+    {
+        'name': 'Zebra QR Label (9-pack ready)',
+        'template_ref': 'zebra/participant-batch',
+        'output_format': PrintJob.Format.ZPL,
+        'content': '^XA^FO40,40^BQN,2,6^FDQA,[[label]]^FS^FO40,200^A0N,28,28^FD[[label]]^FS^XZ',
+        'sample_payload': {
+            'participant_prefix': 'MLTP2-MBY-KWJ-',
+            'range_start': 1,
+            'range_end': 1,
+            'serial_position': 'after_prefix',
+            'label_suffixes': [
+                'base',
+                'BLD-6mls',
+                'BLD-4mls',
+                'BLD-2mls',
+                'PLM1',
+                'PLM2',
+                'BLD-RNA',
+                'NA1',
+                'NA2',
+            ],
+        },
+    },
+    {
+        'name': 'A4 QR Sheet 65-up (38.1x21.2mm)',
+        'template_ref': 'a4/65-up',
+        'output_format': PrintJob.Format.PDF,
+        'content': 'QR [[content]]',
+        'sample_payload': {
+            'labels': ['MLTP2-MBY-KWJ-001'],
+            'pdf_sheet_preset': 'a4-38x21.2',
+            'batch_count': 5,
+        },
+    },
+)
 
 
 def _tenant_schema(request) -> str:
@@ -272,6 +318,73 @@ AGENT_TOOL_ALLOWLIST = {
     'lineage.read',
     'governance.read',
 }
+
+
+DEFAULT_PARTICIPANT_LABEL_SUFFIXES = [
+    '',
+    'BLD-6mls',
+    'BLD-4mls',
+    'BLD-2mls',
+    'PLM1',
+    'PLM2',
+    'BLD-RNA',
+    'NA1',
+    'NA2',
+]
+
+
+def _join_label_part(label: str, part: str) -> str:
+    value = (label or '').strip()
+    token = (part or '').strip()
+    if not token:
+        return value
+    if not value:
+        return token
+    if value.endswith('-'):
+        return f'{value}{token}'
+    return f'{value}-{token}'
+
+
+def _expand_default_participant_labels(payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return payload
+    if isinstance(payload.get('labels'), list) and payload.get('labels'):
+        return payload
+    participant_prefix = (payload.get('participant_prefix') or '').strip()
+    range_start = payload.get('range_start')
+    range_end = payload.get('range_end')
+    serial_position = (payload.get('serial_position') or 'after_prefix').strip()
+    if serial_position not in {'after_prefix', 'at_end'}:
+        serial_position = 'after_prefix'
+    suffixes = payload.get('label_suffixes')
+    if isinstance(suffixes, list):
+        normalized_suffixes = []
+        for item in suffixes:
+            raw = str(item).strip()
+            if raw.lower() in {'base', 'root'}:
+                raw = ''
+            normalized_suffixes.append(raw.lstrip('-'))
+        suffixes = normalized_suffixes
+    else:
+        suffixes = DEFAULT_PARTICIPANT_LABEL_SUFFIXES
+    if not participant_prefix or range_start is None or range_end is None:
+        return payload
+    if not isinstance(range_start, int) or not isinstance(range_end, int):
+        return payload
+    if range_start <= 0 or range_end < range_start:
+        return payload
+    width = max(3, len(str(range_start)), len(str(range_end)))
+    labels: list[str] = []
+    for participant in range(range_start, range_end + 1):
+        serial = f'{participant:0{width}d}'
+        for suffix in suffixes:
+            if serial_position == 'at_end':
+                label = _join_label_part(participant_prefix, suffix)
+                labels.append(_join_label_part(label, serial))
+            else:
+                label = _join_label_part(participant_prefix, serial)
+                labels.append(_join_label_part(label, suffix))
+    return {**payload, 'labels': labels}
 
 
 def _classification_max_sensitivity(values: list[str]) -> int:
@@ -597,6 +710,48 @@ def _print_gateway_to_dict(gateway: PrintGateway) -> dict[str, Any]:
         'created_at': gateway.created_at.isoformat(),
         'updated_at': gateway.updated_at.isoformat(),
     }
+
+
+def _print_template_to_dict(template: PrintTemplate) -> dict[str, Any]:
+    return {
+        'id': str(template.id),
+        'name': template.name,
+        'template_ref': template.template_ref,
+        'output_format': template.output_format,
+        'content': template.content,
+        'sample_payload': template.sample_payload,
+        'created_at': template.created_at.isoformat(),
+        'updated_at': template.updated_at.isoformat(),
+    }
+
+
+def _default_print_template_dicts() -> list[dict[str, Any]]:
+    return [
+        {
+            'id': item['template_ref'],
+            'name': item['name'],
+            'template_ref': item['template_ref'],
+            'output_format': item['output_format'],
+            'content': item['content'],
+            'sample_payload': dict(item['sample_payload']),
+            'created_at': None,
+            'updated_at': None,
+        }
+        for item in DEFAULT_PRINT_TEMPLATE_DEFINITIONS
+    ]
+
+
+def _merge_templates_with_defaults(templates: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    defaults = _default_print_template_dicts()
+    by_ref = {item['template_ref']: item for item in templates}
+    for default_item in defaults:
+        by_ref.setdefault(default_item['template_ref'], default_item)
+    ordered_refs = []
+    for item in [*templates, *defaults]:
+        ref = item['template_ref']
+        if ref not in ordered_refs:
+            ordered_refs.append(ref)
+    return [by_ref[ref] for ref in ordered_refs]
 
 
 def _collaboration_document_to_dict(
@@ -3157,6 +3312,19 @@ def print_jobs(request):
         print_payload = payload.get('payload') or {}
         if not isinstance(print_payload, dict):
             return JsonResponse({'error': 'payload must be an object'}, status=400)
+        if output_format == PrintJob.Format.ZPL:
+            print_payload = _expand_default_participant_labels(print_payload)
+        template = PrintTemplate.objects.filter(template_ref=template_ref).first()
+        if template and template.output_format != output_format:
+            return JsonResponse({'error': 'template_output_format_mismatch'}, status=400)
+        template_content = template.content if template else ''
+        gateway_metadata = {
+            'render_preview': render_label_preview(
+                output_format=output_format,
+                template_content=template_content,
+                payload=print_payload,
+            )
+        }
 
         print_job = PrintJob.objects.create(
             template_ref=template_ref,
@@ -3164,6 +3332,7 @@ def print_jobs(request):
             output_format=output_format,
             destination=destination,
             status=PrintJob.Status.PENDING,
+            gateway_metadata=gateway_metadata,
         )
         tenant_schema = _tenant_schema(request)
         maybe_publish_event(
@@ -3207,6 +3376,35 @@ def print_job_detail(request, job_id: str):
     except (ValidationError, PrintJob.DoesNotExist):
         return JsonResponse({'error': 'not_found'}, status=404)
     return JsonResponse(_print_job_to_dict(print_job))
+
+
+@csrf_exempt
+def print_job_preview_pdf(request, job_id: str):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    try:
+        print_job = PrintJob.objects.get(id=job_id)
+    except (ValidationError, PrintJob.DoesNotExist):
+        return JsonResponse({'error': 'not_found'}, status=404)
+    preview = (print_job.gateway_metadata or {}).get('render_preview') or {}
+    pdf_base64 = preview.get('pdf_base64')
+    if not isinstance(pdf_base64, str) or not pdf_base64.strip():
+        return JsonResponse({'error': 'preview_pdf_not_available'}, status=404)
+    try:
+        pdf_bytes = base64.b64decode(pdf_base64)
+    except (ValueError, binascii.Error):
+        return JsonResponse({'error': 'invalid_preview_pdf'}, status=500)
+    response = HttpResponse(pdf_bytes, content_type='application/pdf')
+    response['Content-Disposition'] = (
+        f'attachment; filename="print-job-{print_job.id}-preview.pdf"'
+    )
+    return response
 
 
 @csrf_exempt
@@ -3335,6 +3533,54 @@ def print_gateways(request):
             last_seen_version=(payload.get('last_seen_version') or '').strip(),
         )
         return JsonResponse(_print_gateway_to_dict(gateway), status=201)
+
+    return JsonResponse({'error': 'method_not_allowed'}, status=405)
+
+
+@csrf_exempt
+def print_templates(request):
+    if request.method == 'GET':
+        forbidden = require_any_role(
+            request,
+            {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+        )
+        if forbidden:
+            return forbidden
+        qs = PrintTemplate.objects.order_by('-updated_at')
+        return JsonResponse({'items': [_print_template_to_dict(item) for item in qs]})
+
+    if request.method == 'POST':
+        forbidden = require_any_role(request, {'catalog.editor', 'tenant.admin'})
+        if forbidden:
+            return forbidden
+        payload = _parse_json_body(request)
+        if payload is None:
+            return JsonResponse({'error': 'invalid_json'}, status=400)
+        name = (payload.get('name') or '').strip()
+        template_ref = (payload.get('template_ref') or '').strip()
+        output_format = (payload.get('output_format') or '').strip()
+        if not name or not template_ref or not output_format:
+            return JsonResponse(
+                {'error': 'name, template_ref, and output_format are required'},
+                status=400,
+            )
+        if output_format not in {PrintJob.Format.ZPL, PrintJob.Format.PDF}:
+            return JsonResponse({'error': 'invalid_output_format'}, status=400)
+        if PrintTemplate.objects.filter(template_ref=template_ref).exists():
+            return JsonResponse({'error': 'template_ref_already_exists'}, status=409)
+        sample_payload = payload.get('sample_payload')
+        if sample_payload is None:
+            sample_payload = {}
+        if not isinstance(sample_payload, dict):
+            return JsonResponse({'error': 'sample_payload must be an object'}, status=400)
+        template = PrintTemplate.objects.create(
+            name=name,
+            template_ref=template_ref,
+            output_format=output_format,
+            content=(payload.get('content') or '').strip(),
+            sample_payload=sample_payload,
+        )
+        return JsonResponse(_print_template_to_dict(template), status=201)
 
     return JsonResponse({'error': 'method_not_allowed'}, status=405)
 
@@ -6296,17 +6542,61 @@ def ui_operations_dashboard(request):
     )
     if forbidden:
         return forbidden
+    return JsonResponse(_ui_operations_dashboard_payload(request))
+
+
+@csrf_exempt
+def ui_operations_stewardship_workbench(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return JsonResponse(_ui_operations_stewardship_payload(request))
+
+
+@csrf_exempt
+def ui_operations_orchestration_monitor(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return JsonResponse(_ui_operations_orchestration_payload(request))
+
+
+@csrf_exempt
+def ui_operations_agent_monitor(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return JsonResponse(_ui_operations_agent_payload(request))
+
+
+def _ui_operations_dashboard_payload(request) -> dict[str, Any]:
     project_id = request.GET.get('project_id')
     roles = _request_roles(request)
     stewardship_qs = StewardshipItem.objects.all()
     workflow_qs = WorkflowRun.objects.all()
     orchestration_qs = OrchestrationRun.objects.all()
     agent_qs = AgentRun.objects.all()
+    print_job_qs = PrintJob.objects.all()
+    print_gateway_qs = PrintGateway.objects.all()
+    print_template_qs = PrintTemplate.objects.all()
     if project_id:
         orchestration_qs = orchestration_qs.filter(project_id=project_id)
-        agent_qs = agent_qs.filter(
-            prompt__icontains=f'project:{project_id}'
-        )
+        agent_qs = agent_qs.filter(prompt__icontains=f'project:{project_id}')
     stewardship_counts = {
         status: stewardship_qs.filter(status=status).count()
         for status in StewardshipItem.Status.values
@@ -6323,43 +6613,47 @@ def ui_operations_dashboard(request):
         status: agent_qs.filter(status=status).count()
         for status in AgentRun.Status.values
     }
-    return JsonResponse(
-        {
-            'project_id': project_id,
-            'cards': {
-                'stewardship': stewardship_counts,
-                'workflow': workflow_counts,
-                'orchestration': orchestration_counts,
-                'agent': agent_counts,
-            },
-            'capabilities': {
-                'can_view': bool(
-                    roles
-                    & {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'}
-                ),
-                'can_manage_stewardship': bool(roles & {'policy.admin', 'tenant.admin'}),
-                'can_queue_orchestration_runs': bool(
-                    roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
-                ),
-                'can_manage_orchestration': bool(roles & {'policy.admin', 'tenant.admin'}),
-                'can_manage_agents': bool(
-                    roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
-                ),
-            },
-        }
-    )
+    printing_counts = {
+        'jobs': {
+            status: print_job_qs.filter(status=status).count()
+            for status in PrintJob.Status.values
+        },
+        'gateways': {
+            status: print_gateway_qs.filter(status=status).count()
+            for status in PrintGateway.Status.values
+        },
+        'templates': print_template_qs.count(),
+    }
+    return {
+        'project_id': project_id,
+        'cards': {
+            'stewardship': stewardship_counts,
+            'workflow': workflow_counts,
+            'orchestration': orchestration_counts,
+            'agent': agent_counts,
+            'printing': printing_counts,
+        },
+        'capabilities': {
+            'can_view': bool(
+                roles
+                & {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'}
+            ),
+            'can_manage_stewardship': bool(roles & {'policy.admin', 'tenant.admin'}),
+            'can_queue_orchestration_runs': bool(
+                roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
+            ),
+            'can_manage_orchestration': bool(roles & {'policy.admin', 'tenant.admin'}),
+            'can_manage_agents': bool(
+                roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
+            ),
+            'can_manage_printing': bool(
+                roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
+            ),
+        },
+    }
 
 
-@csrf_exempt
-def ui_operations_stewardship_workbench(request):
-    if request.method != 'GET':
-        return JsonResponse({'error': 'method_not_allowed'}, status=405)
-    forbidden = require_any_role(
-        request,
-        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
-    )
-    if forbidden:
-        return forbidden
+def _ui_operations_stewardship_payload(request) -> dict[str, Any]:
     roles = _request_roles(request)
     can_manage = bool(roles & {'policy.admin', 'tenant.admin'})
     qs = StewardshipItem.objects.order_by('-created_at')
@@ -6398,21 +6692,10 @@ def ui_operations_stewardship_workbench(request):
                 allowed_actions.append('reopen')
         item_data['allowed_actions'] = sorted(set(allowed_actions))
         items.append(item_data)
-    return JsonResponse(
-        {'items': items, 'capabilities': {'can_manage_stewardship': can_manage}}
-    )
+    return {'items': items, 'capabilities': {'can_manage_stewardship': can_manage}}
 
 
-@csrf_exempt
-def ui_operations_orchestration_monitor(request):
-    if request.method != 'GET':
-        return JsonResponse({'error': 'method_not_allowed'}, status=405)
-    forbidden = require_any_role(
-        request,
-        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
-    )
-    if forbidden:
-        return forbidden
+def _ui_operations_orchestration_payload(request) -> dict[str, Any]:
     roles = _request_roles(request)
     project_id = request.GET.get('project_id')
     workflows_qs = OrchestrationWorkflow.objects.order_by('-created_at')
@@ -6420,23 +6703,204 @@ def ui_operations_orchestration_monitor(request):
     if project_id:
         workflows_qs = workflows_qs.filter(project_id=project_id)
         runs_qs = runs_qs.filter(project_id=project_id)
-    return JsonResponse(
-        {
-            'project_id': project_id,
-            'workflows': [_orchestration_workflow_to_dict(item) for item in workflows_qs[:100]],
-            'runs': [_orchestration_run_to_dict(item) for item in runs_qs[:100]],
-            'capabilities': {
-                'can_queue_runs': bool(
-                    roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
-                ),
-                'can_cancel_runs': bool(roles & {'policy.admin', 'tenant.admin'}),
-            },
-        }
+    can_queue_runs = bool(
+        roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
     )
+    can_cancel_runs = bool(roles & {'policy.admin', 'tenant.admin'})
+    runs = []
+    for item in runs_qs[:100]:
+        item_data = _orchestration_run_to_dict(item)
+        allowed_actions = []
+        if can_queue_runs and item.status == OrchestrationRun.Status.QUEUED:
+            allowed_actions.append('start')
+        if can_cancel_runs and item.status in {
+            OrchestrationRun.Status.QUEUED,
+            OrchestrationRun.Status.RUNNING,
+        }:
+            allowed_actions.append('cancel')
+        item_data['allowed_actions'] = allowed_actions
+        runs.append(item_data)
+    return {
+        'project_id': project_id,
+        'workflows': [_orchestration_workflow_to_dict(item) for item in workflows_qs[:100]],
+        'runs': runs,
+        'capabilities': {
+            'can_queue_runs': can_queue_runs,
+            'can_cancel_runs': can_cancel_runs,
+        },
+    }
+
+
+def _ui_operations_agent_payload(request) -> dict[str, Any]:
+    roles = _request_roles(request)
+    project_id = request.GET.get('project_id')
+    qs = AgentRun.objects.order_by('-created_at')
+    if project_id:
+        qs = qs.filter(prompt__icontains=f'project:{project_id}')
+    can_create_runs = bool(
+        roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
+    )
+    can_cancel_runs = bool(
+        roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
+    )
+    can_materialize_timeouts = bool(
+        roles & {'policy.admin', 'tenant.admin'}
+    )
+    runs = []
+    for item in qs[:100]:
+        item_data = _agent_run_to_dict(item)
+        allowed_actions = []
+        if can_create_runs and item.status == AgentRun.Status.QUEUED:
+            allowed_actions.append('start')
+        if can_create_runs and item.status == AgentRun.Status.RUNNING:
+            allowed_actions.append('complete')
+            allowed_actions.append('fail')
+        if can_cancel_runs and item.status in {
+            AgentRun.Status.QUEUED,
+            AgentRun.Status.RUNNING,
+        }:
+            allowed_actions.append('cancel')
+        if can_materialize_timeouts and item.status == AgentRun.Status.RUNNING:
+            allowed_actions.append('materialize_timeouts')
+        item_data['allowed_actions'] = allowed_actions
+        runs.append(item_data)
+    return {
+        'project_id': project_id,
+        'runs': runs,
+        'capabilities': {
+            'can_create_runs': can_create_runs,
+            'can_cancel_runs': can_cancel_runs,
+            'can_materialize_timeouts': can_materialize_timeouts,
+        },
+    }
+
+
+def _ui_operations_printing_payload(request) -> dict[str, Any]:
+    roles = _request_roles(request)
+    can_create_jobs = bool(roles & {'catalog.editor', 'tenant.admin'})
+    can_manage_jobs = bool(roles & {'policy.admin', 'tenant.admin'})
+    can_manage_gateways = bool(roles & {'policy.admin', 'tenant.admin'})
+    can_manage_templates = bool(roles & {'catalog.editor', 'tenant.admin'})
+
+    jobs_qs = PrintJob.objects.order_by('-created_at')
+    job_status_filter = (request.GET.get('job_status') or '').strip()
+    if job_status_filter:
+        jobs_qs = jobs_qs.filter(status=job_status_filter)
+
+    gateways_qs = PrintGateway.objects.order_by('-updated_at')
+    gateway_status_filter = (request.GET.get('gateway_status') or '').strip()
+    if gateway_status_filter:
+        gateways_qs = gateways_qs.filter(status=gateway_status_filter)
+    templates_qs = PrintTemplate.objects.order_by('-updated_at')
+
+    jobs = []
+    for item in jobs_qs[:200]:
+        item_data = _print_job_to_dict(item)
+        allowed_actions = []
+        if can_manage_jobs and item.status in {PrintJob.Status.PENDING, PrintJob.Status.RETRYING}:
+            allowed_actions.extend(
+                [
+                    PrintJob.Status.RETRYING,
+                    PrintJob.Status.COMPLETED,
+                    PrintJob.Status.FAILED,
+                ]
+            )
+        item_data['allowed_actions'] = sorted(set(allowed_actions))
+        jobs.append(item_data)
+
+    return {
+        'jobs': jobs,
+        'gateways': [_print_gateway_to_dict(item) for item in gateways_qs[:200]],
+        'templates': [_print_template_to_dict(item) for item in templates_qs[:200]],
+        'cards': {
+            'jobs': {
+                status: PrintJob.objects.filter(status=status).count()
+                for status in PrintJob.Status.values
+            },
+            'gateways': {
+                status: PrintGateway.objects.filter(status=status).count()
+                for status in PrintGateway.Status.values
+            },
+            'templates': PrintTemplate.objects.count(),
+        },
+        'capabilities': {
+            'can_create_jobs': can_create_jobs,
+            'can_manage_jobs': can_manage_jobs,
+            'can_manage_gateways': can_manage_gateways,
+            'can_manage_templates': can_manage_templates,
+        },
+    }
+
+
+def _user_portal_dashboard_payload(request) -> dict[str, Any]:
+    roles = _request_roles(request)
+    roles_enforced = os.environ.get('EDMP_ENFORCE_ROLES', '').lower() in {
+        '1',
+        'true',
+        'yes',
+    }
+    can_submit_print_jobs = (
+        bool(roles & {'catalog.editor', 'tenant.admin'}) if roles_enforced else True
+    )
+    can_manage_templates = (
+        bool(roles & {'catalog.editor', 'tenant.admin'}) if roles_enforced else True
+    )
+    can_manage_printers = (
+        bool(roles & {'policy.admin', 'tenant.admin'}) if roles_enforced else True
+    )
+    can_view_operations = (
+        bool(roles & {'catalog.editor', 'policy.admin', 'tenant.admin'})
+        if roles_enforced
+        else True
+    )
+    templates = _merge_templates_with_defaults(
+        [_print_template_to_dict(item) for item in PrintTemplate.objects.order_by('-updated_at')[:100]]
+    )[:100]
+    gateways = [_print_gateway_to_dict(item) for item in PrintGateway.objects.order_by('-updated_at')[:100]]
+    jobs = [_print_job_to_dict(item) for item in PrintJob.objects.order_by('-created_at')[:20]]
+    return {
+        'templates': templates,
+        'gateways': gateways,
+        'recent_jobs': jobs,
+        'cards': {
+            'templates': len(templates),
+            'printers': len(gateways),
+            'recent_jobs': len(jobs),
+        },
+        'user_context': {
+            'user_id': (request.headers.get('X-User-Id') or 'anonymous').strip(),
+            'roles': sorted(roles),
+            'tenant_schema': _tenant_schema(request),
+        },
+        'navigation': {'can_view_operations': can_view_operations},
+        'capabilities': {
+            'can_submit_print_jobs': can_submit_print_jobs,
+            'can_manage_templates': can_manage_templates,
+            'can_manage_printers': can_manage_printers,
+        },
+    }
+
+
+def _ui_base_template() -> str:
+    if settings.EDMP_UI_MATERIAL_ENABLED:
+        try:
+            get_template('material/base.html')
+            return 'material/base.html'
+        except TemplateDoesNotExist:
+            pass
+    return 'core/ui/base_fallback.html'
+
+
+def _ui_feedback_context(request) -> dict[str, Any]:
+    return {
+        'ui_message': (request.GET.get('ui_message') or '').strip(),
+        'ui_error': (request.GET.get('ui_error') or '').strip().lower()
+        in {'1', 'true', 'yes'},
+    }
 
 
 @csrf_exempt
-def ui_operations_agent_monitor(request):
+def ui_operations_dashboard_page(request):
     if request.method != 'GET':
         return JsonResponse({'error': 'method_not_allowed'}, status=405)
     forbidden = require_any_role(
@@ -6445,27 +6909,136 @@ def ui_operations_agent_monitor(request):
     )
     if forbidden:
         return forbidden
-    roles = _request_roles(request)
-    project_id = request.GET.get('project_id')
-    qs = AgentRun.objects.order_by('-created_at')
-    if project_id:
-        qs = qs.filter(prompt__icontains=f'project:{project_id}')
-    return JsonResponse(
+    return render(
+        request,
+        'core/ui/operations_dashboard.html',
         {
-            'project_id': project_id,
-            'runs': [_agent_run_to_dict(item) for item in qs[:100]],
-            'capabilities': {
-                'can_create_runs': bool(
-                    roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
-                ),
-                'can_cancel_runs': bool(
-                    roles & {'catalog.editor', 'policy.admin', 'tenant.admin'}
-                ),
-                'can_materialize_timeouts': bool(
-                    roles & {'policy.admin', 'tenant.admin'}
-                ),
-            },
-        }
+            'base_template': _ui_base_template(),
+            'active_nav': 'dashboard',
+            'payload': _ui_operations_dashboard_payload(request),
+            'project_id': request.GET.get('project_id', ''),
+            **_ui_feedback_context(request),
+        },
+    )
+
+
+@csrf_exempt
+def ui_operations_stewardship_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'core/ui/operations_stewardship.html',
+        {
+            'base_template': _ui_base_template(),
+            'active_nav': 'stewardship',
+            'payload': _ui_operations_stewardship_payload(request),
+            'status_filter': request.GET.get('status', ''),
+            'severity_filter': request.GET.get('severity', ''),
+            'status_options': StewardshipItem.Status.values,
+            'severity_options': StewardshipItem.Severity.values,
+            **_ui_feedback_context(request),
+        },
+    )
+
+
+@csrf_exempt
+def ui_operations_orchestration_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'core/ui/operations_orchestration.html',
+        {
+            'base_template': _ui_base_template(),
+            'active_nav': 'orchestration',
+            'payload': _ui_operations_orchestration_payload(request),
+            'project_id': request.GET.get('project_id', ''),
+            **_ui_feedback_context(request),
+        },
+    )
+
+
+@csrf_exempt
+def ui_operations_agent_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'core/ui/operations_agent.html',
+        {
+            'base_template': _ui_base_template(),
+            'active_nav': 'agent',
+            'payload': _ui_operations_agent_payload(request),
+            'project_id': request.GET.get('project_id', ''),
+            **_ui_feedback_context(request),
+        },
+    )
+
+
+@csrf_exempt
+def ui_operations_printing_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'core/ui/operations_printing.html',
+        {
+            'base_template': _ui_base_template(),
+            'active_nav': 'printing',
+            'payload': _ui_operations_printing_payload(request),
+            'job_status_filter': request.GET.get('job_status', ''),
+            'gateway_status_filter': request.GET.get('gateway_status', ''),
+            'job_status_options': PrintJob.Status.values,
+            'gateway_status_options': PrintGateway.Status.values,
+            'job_format_options': PrintJob.Format.values,
+            **_ui_feedback_context(request),
+        },
+    )
+
+
+@csrf_exempt
+def user_portal_dashboard_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_any_role(
+        request,
+        {'catalog.reader', 'catalog.editor', 'policy.admin', 'tenant.admin'},
+    )
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'core/ui/user_dashboard.html',
+        {
+            'active_nav': 'home',
+            'payload': _user_portal_dashboard_payload(request),
+            **_ui_feedback_context(request),
+        },
     )
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,7 @@ django-tenants==3.10.0
 pika==1.3.2
 psycopg[binary]==3.1.18
 prometheus-client==0.20.0
+django-material
+qrcode==8.2
+reportlab==4.4.2
+pylabels==1.2.1

--- a/backend/tenants/middleware.py
+++ b/backend/tenants/middleware.py
@@ -1,6 +1,11 @@
+import os
+
 from django.db import connection
+from django.db.models import Q
 from django.http import JsonResponse
 from django_tenants.middleware.main import TenantMainMiddleware
+
+from .models import TenantServiceRoute, normalize_domain, normalize_subdomain_label
 
 
 class EDMPTenantMiddleware(TenantMainMiddleware):
@@ -16,6 +21,51 @@ class EDMPTenantMiddleware(TenantMainMiddleware):
     PUBLIC_ENDPOINT_PATHS = {'/healthz', '/livez', '/readyz', '/metrics'}
     PUBLIC_ENDPOINT_PREFIXES = ('/api/v1/tenants', '/admin')
 
+    def _resolve_service_route(self, hostname: str):
+        normalized_host = normalize_domain(hostname)
+        route = (
+            TenantServiceRoute.objects.select_related('tenant')
+            .filter(domain=normalized_host, is_enabled=True)
+            .first()
+        )
+        if route:
+            return route
+
+        base_domain = normalize_domain(
+            os.environ.get('EDMP_BASE_DOMAIN', 'edmp.co.tz')
+        )
+        suffix = f'.{base_domain}'
+        if not normalized_host.endswith(suffix):
+            return None
+        labels = [
+            normalize_subdomain_label(item)
+            for item in normalized_host[: -len(suffix)].split('.')
+            if item
+        ]
+        if len(labels) == 1:
+            tenant_slug = labels[0]
+            return (
+                TenantServiceRoute.objects.select_related('tenant')
+                .filter(
+                    tenant_slug=tenant_slug,
+                    base_domain=base_domain,
+                    is_enabled=True,
+                )
+                .first()
+            )
+        if len(labels) == 2:
+            first, second = labels
+            return (
+                TenantServiceRoute.objects.select_related('tenant')
+                .filter(base_domain=base_domain, is_enabled=True)
+                .filter(
+                    Q(service_key=first, tenant_slug=second)
+                    | Q(service_key=second, tenant_slug=first)
+                )
+                .first()
+            )
+        return None
+
     def process_request(self, request):
         # Kubernetes liveness/readiness probes typically don't send a tenant
         # hostname. For a multi-tenant app, these endpoints must still work to
@@ -29,4 +79,11 @@ class EDMPTenantMiddleware(TenantMainMiddleware):
         return super().process_request(request)
 
     def no_tenant_found(self, request, hostname):
+        route = self._resolve_service_route(hostname)
+        if route:
+            request.tenant = route.tenant
+            request.tenant.domain_url = hostname
+            connection.set_tenant(request.tenant)
+            self.setup_url_routing(request)
+            return None
         return JsonResponse({'error': 'tenant_not_found'}, status=404)

--- a/backend/tenants/migrations/0002_tenantserviceroute.py
+++ b/backend/tenants/migrations/0002_tenantserviceroute.py
@@ -1,0 +1,30 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tenants', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TenantServiceRoute',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('service_key', models.CharField(max_length=64)),
+                ('tenant_slug', models.CharField(max_length=64)),
+                ('base_domain', models.CharField(max_length=253)),
+                ('domain', models.CharField(max_length=253, unique=True)),
+                ('workspace_path', models.CharField(blank=True, default='', max_length=128)),
+                ('is_enabled', models.BooleanField(default=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+                ('tenant', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='service_routes', to='tenants.tenant')),
+            ],
+            options={
+                'constraints': [models.UniqueConstraint(fields=('service_key', 'tenant_slug', 'base_domain'), name='uniq_tenant_service_route')],
+            },
+        ),
+    ]

--- a/backend/tenants/models.py
+++ b/backend/tenants/models.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import urlsplit
 
 from django.db import models
@@ -38,6 +39,41 @@ def normalize_domain(value: str) -> str:
     return value.lower()
 
 
+def normalize_subdomain_label(value: str) -> str:
+    normalized = re.sub(r'[^a-z0-9-]+', '-', (value or '').strip().lower())
+    normalized = re.sub(r'-+', '-', normalized).strip('-')
+    return normalized
+
+
+def build_service_tenant_domain(service: str, tenant_slug: str, base_domain: str) -> str:
+    normalized_service = normalize_subdomain_label(service)
+    normalized_tenant = normalize_subdomain_label(tenant_slug)
+    normalized_base = normalize_domain(base_domain)
+    if not normalized_service or not normalized_tenant or not normalized_base:
+        raise ValueError('service, tenant_slug, and base_domain are required')
+    return f'{normalized_service}.{normalized_tenant}.{normalized_base}'
+
+
+def parse_service_tenant_domain(hostname: str, base_domain: str) -> tuple[str, str] | None:
+    normalized_host = normalize_domain(hostname)
+    normalized_base = normalize_domain(base_domain)
+    if not normalized_host or not normalized_base:
+        return None
+    suffix = f'.{normalized_base}'
+    if not normalized_host.endswith(suffix):
+        return None
+    labels = normalized_host[: -len(suffix)].split('.')
+    if len(labels) != 2:
+        return None
+    service, tenant_slug = (
+        normalize_subdomain_label(labels[0]),
+        normalize_subdomain_label(labels[1]),
+    )
+    if not service or not tenant_slug:
+        return None
+    return service, tenant_slug
+
+
 class Domain(DomainMixin):
     def _normalize(self) -> None:
         if self.domain:
@@ -56,4 +92,32 @@ class Domain(DomainMixin):
         return super().save(*args, **kwargs)
 
 
-# Create your models here.
+class TenantServiceRoute(models.Model):
+    tenant = models.ForeignKey(
+        Tenant, on_delete=models.CASCADE, related_name='service_routes'
+    )
+    service_key = models.CharField(max_length=64)
+    tenant_slug = models.CharField(max_length=64)
+    base_domain = models.CharField(max_length=253)
+    domain = models.CharField(max_length=253, unique=True)
+    workspace_path = models.CharField(max_length=128, blank=True, default='')
+    is_enabled = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=['service_key', 'tenant_slug', 'base_domain'],
+                name='uniq_tenant_service_route',
+            ),
+        ]
+
+    def save(self, *args, **kwargs):
+        self.service_key = normalize_subdomain_label(self.service_key)
+        self.tenant_slug = normalize_subdomain_label(self.tenant_slug)
+        self.base_domain = normalize_domain(self.base_domain)
+        self.domain = build_service_tenant_domain(
+            self.service_key, self.tenant_slug, self.base_domain
+        )
+        return super().save(*args, **kwargs)

--- a/backend/tenants/tests.py
+++ b/backend/tenants/tests.py
@@ -1,3 +1,37 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import (
+    build_service_tenant_domain,
+    normalize_domain,
+    normalize_subdomain_label,
+    parse_service_tenant_domain,
+)
+
+
+class TenantDomainModelTests(TestCase):
+    def test_normalize_domain_strips_scheme_and_port(self):
+        self.assertEqual(normalize_domain('https://App.Example.COM:8443/path'), 'app.example.com')
+
+    def test_normalize_subdomain_label(self):
+        self.assertEqual(normalize_subdomain_label(' Print Service__A '), 'print-service-a')
+
+    def test_build_service_tenant_domain(self):
+        self.assertEqual(
+            build_service_tenant_domain('printing', 'tenant-alpha', 'platform.example.com'),
+            'printing.tenant-alpha.platform.example.com',
+        )
+
+    def test_parse_service_tenant_domain(self):
+        parsed = parse_service_tenant_domain(
+            'printing.tenant-alpha.platform.example.com',
+            'platform.example.com',
+        )
+        self.assertEqual(parsed, ('printing', 'tenant-alpha'))
+
+    def test_parse_service_tenant_domain_rejects_non_matching_base(self):
+        self.assertIsNone(
+            parse_service_tenant_domain(
+                'printing.tenant-alpha.other.example.com',
+                'platform.example.com',
+            )
+        )

--- a/backend/tenants/views.py
+++ b/backend/tenants/views.py
@@ -10,7 +10,13 @@ from django_tenants.utils import schema_context
 
 from core.events import maybe_publish_audit_event, maybe_publish_event
 from core.identity import require_role
-from .models import Domain, Tenant
+from .models import (
+    Domain,
+    Tenant,
+    TenantServiceRoute,
+    build_service_tenant_domain,
+    normalize_subdomain_label,
+)
 
 
 def _parse_json_body(request):
@@ -28,6 +34,19 @@ def _tenant_to_dict(tenant: Tenant) -> dict:
         'name': tenant.name,
         'created_on': tenant.created_on.isoformat(),
         'domains': [d.domain for d in tenant.domains.order_by('id')],
+    }
+
+
+def _service_route_to_dict(route: TenantServiceRoute) -> dict:
+    return {
+        'id': route.id,
+        'tenant_id': route.tenant_id,
+        'service_key': route.service_key,
+        'tenant_slug': route.tenant_slug,
+        'base_domain': route.base_domain,
+        'domain': route.domain,
+        'workspace_path': route.workspace_path or None,
+        'is_enabled': route.is_enabled,
     }
 
 
@@ -88,5 +107,63 @@ def tenants(request):
                 rabbitmq_url=os.environ.get('RABBITMQ_URL'),
             )
             return JsonResponse(_tenant_to_dict(tenant), status=201)
+
+    return JsonResponse({'error': 'method_not_allowed'}, status=405)
+
+
+@csrf_exempt
+def tenant_services(request):
+    with schema_context('public'):
+        if request.method == 'GET':
+            forbidden = require_role(request, 'tenant.admin')
+            if forbidden:
+                return forbidden
+            tenant_id = request.GET.get('tenant_id')
+            qs = TenantServiceRoute.objects.select_related('tenant').order_by('id')
+            if tenant_id:
+                qs = qs.filter(tenant_id=tenant_id)
+            return JsonResponse({'items': [_service_route_to_dict(item) for item in qs]})
+
+        if request.method == 'POST':
+            forbidden = require_role(request, 'tenant.admin')
+            if forbidden:
+                return forbidden
+            payload = _parse_json_body(request)
+            if payload is None:
+                return JsonResponse({'error': 'invalid_json'}, status=400)
+            tenant_id = payload.get('tenant_id')
+            service_key = normalize_subdomain_label(payload.get('service_key') or '')
+            tenant_slug = normalize_subdomain_label(payload.get('tenant_slug') or '')
+            base_domain = payload.get('base_domain')
+            if not tenant_id or not service_key or not tenant_slug or not base_domain:
+                return JsonResponse(
+                    {
+                        'error': 'tenant_id, service_key, tenant_slug, and base_domain are required'
+                    },
+                    status=400,
+                )
+            try:
+                tenant = Tenant.objects.get(id=tenant_id)
+            except (ValidationError, Tenant.DoesNotExist):
+                return JsonResponse({'error': 'tenant_not_found'}, status=404)
+            try:
+                route = TenantServiceRoute(
+                    tenant=tenant,
+                    service_key=service_key,
+                    tenant_slug=tenant_slug,
+                    base_domain=base_domain,
+                    domain=build_service_tenant_domain(
+                        service_key, tenant_slug, base_domain
+                    ),
+                    workspace_path=(payload.get('workspace_path') or '').strip(),
+                    is_enabled=bool(payload.get('is_enabled', True)),
+                )
+                route.full_clean()
+                route.save()
+            except ValidationError:
+                return JsonResponse({'error': 'validation_error'}, status=400)
+            except IntegrityError:
+                return JsonResponse({'error': 'conflict'}, status=409)
+            return JsonResponse(_service_route_to_dict(route), status=201)
 
     return JsonResponse({'error': 'method_not_allowed'}, status=405)

--- a/backend/tests/test_printing_api.py
+++ b/backend/tests/test_printing_api.py
@@ -281,3 +281,362 @@ def test_print_gateway_role_and_token_enforcement(monkeypatch):
         HTTP_X_PRINT_GATEWAY_TOKEN='secret-token',
     )
     assert ok_token.status_code == 200
+
+
+@pytest.mark.django_db(transaction=True)
+def test_print_template_lifecycle_and_tenant_scope():
+    host_a, host_b = _create_tenants()
+    client = Client()
+
+    created = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'Shipping Label',
+                'template_ref': 'label/shipping-v2',
+                'output_format': 'zpl',
+                'content': '^XA^FO20,20^FDOrder:^FS',
+                'sample_payload': {'order_id': 'SO-123'},
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host_a,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    assert created.json()['template_ref'] == 'label/shipping-v2'
+
+    listed_a = client.get('/api/v1/printing/templates', HTTP_HOST=host_a)
+    assert listed_a.status_code == 200
+    assert len(listed_a.json()['items']) == 1
+
+    listed_b = client.get('/api/v1/printing/templates', HTTP_HOST=host_b)
+    assert listed_b.status_code == 200
+    assert listed_b.json()['items'] == []
+
+
+@pytest.mark.django_db(transaction=True)
+def test_print_job_stores_render_preview_from_template():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'Preview Template',
+                'template_ref': 'label/preview-v1',
+                'output_format': 'pdf',
+                'content': 'QR [[content]] for [[order_id]]',
+                'sample_payload': {'content': 'ABC', 'order_id': 'SO-1'},
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'label/preview-v1',
+                'output_format': 'pdf',
+                'destination': 'printer-a',
+                'payload': {'content': 'XYZ', 'order_id': 'SO-2'},
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    preview = created.json()['gateway_metadata']['render_preview']
+    assert preview['engine'] == 'qrcode-reportlab-pylabels'
+    assert preview['rendered'] == 'QR XYZ for SO-2'
+
+
+@pytest.mark.django_db(transaction=True)
+def test_zebra_batch_labels_render_preview():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'Zebra Participant Labels',
+                'template_ref': 'zebra/participant-batch',
+                'output_format': 'zpl',
+                'content': '^XA^FO40,40^BQN,2,6^FDQA,[[label]]^FS^XZ',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    labels = [
+        'MLTP2-MBY-KWJ-001',
+        'MLTP2-MBY-KWJ-001-BLD-6mls',
+        'MLTP2-MBY-KWJ-001-BLD-4mls',
+        'MLTP2-MBY-KWJ-001-BLD-2mls',
+        'MLTP2-MBY-KWJ-001-PLM1',
+        'MLTP2-MBY-KWJ-001-PLM2',
+        'MLTP2-MBY-KWJ-001-BLD-RNA',
+        'MLTP2-MBY-KWJ-001-NA1',
+        'MLTP2-MBY-KWJ-001-NA2',
+    ]
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'zebra/participant-batch',
+                'output_format': 'zpl',
+                'destination': 'zebra-printer-1',
+                'payload': {'labels': labels},
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    preview = created.json()['gateway_metadata']['render_preview']
+    assert preview['engine'] == 'zpl-inline'
+    assert preview['label_count'] == 9
+    assert 'MLTP2-MBY-KWJ-001-BLD-RNA' in preview['rendered']
+
+
+@pytest.mark.django_db(transaction=True)
+def test_zebra_default_batch_from_participant_range():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'Zebra Participant Labels',
+                'template_ref': 'zebra/participant-range',
+                'output_format': 'zpl',
+                'content': '^XA^FO40,40^BQN,2,6^FDQA,[[label]]^FS^XZ',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'zebra/participant-range',
+                'output_format': 'zpl',
+                'destination': 'zebra-printer-1',
+                'payload': {
+                    'participant_prefix': 'MLTP2-MBY-KWJ-',
+                    'range_start': 1,
+                    'range_end': 2,
+                },
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    assert len(created.json()['payload']['labels']) == 18
+    assert created.json()['payload']['labels'][0] == 'MLTP2-MBY-KWJ-001'
+    assert created.json()['payload']['labels'][9] == 'MLTP2-MBY-KWJ-002'
+
+
+@pytest.mark.django_db(transaction=True)
+def test_zebra_range_supports_serial_at_end_and_custom_suffixes():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'Zebra Participant Labels',
+                'template_ref': 'zebra/participant-range-end',
+                'output_format': 'zpl',
+                'content': '^XA^FO40,40^BQN,2,6^FDQA,[[label]]^FS^XZ',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'zebra/participant-range-end',
+                'output_format': 'zpl',
+                'destination': 'zebra-printer-1',
+                'payload': {
+                    'participant_prefix': 'MLTP2-MBY-KWJ',
+                    'range_start': 1,
+                    'range_end': 1,
+                    'serial_position': 'at_end',
+                    'label_suffixes': ['base', 'BLD-6mls'],
+                },
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    labels = created.json()['payload']['labels']
+    assert labels == ['MLTP2-MBY-KWJ-001', 'MLTP2-MBY-KWJ-BLD-6mls-001']
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pdf_sheet_preview_with_labels_and_preset():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'A4 Sheet Template',
+                'template_ref': 'a4/qr-sheet',
+                'output_format': 'pdf',
+                'content': 'QR [[content]]',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'a4/qr-sheet',
+                'output_format': 'pdf',
+                'destination': 'office-printer-1',
+                'payload': {
+                    'labels': ['A4-001', 'A4-002', 'A4-003'],
+                    'pdf_sheet_preset': 'a4-38x21.2',
+                },
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    preview = created.json()['gateway_metadata']['render_preview']
+    assert preview['engine'] == 'qrcode-reportlab-pylabels'
+    assert preview['sheet_preset'] == 'a4-38x21.2'
+    assert preview['label_count'] == 3
+    assert preview['layout']['grid'] == [5, 13]
+    assert preview['layout']['label_size_mm'] == [38.1, 21.2]
+    assert 'pdf_base64' in preview or 'render_error' in preview
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a4_65_labels_preview_downloadable_when_available():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'A4 65-up',
+                'template_ref': 'a4/65-up',
+                'output_format': 'pdf',
+                'content': 'QR [[content]]',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    labels = [f'A4-{idx:03d}' for idx in range(1, 66)]
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'a4/65-up',
+                'output_format': 'pdf',
+                'destination': 'office-printer-1',
+                'payload': {
+                    'labels': labels,
+                    'pdf_sheet_preset': 'a4-38x21.2',
+                },
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    preview = created.json()['gateway_metadata']['render_preview']
+    assert preview['label_count'] == 65
+    if 'pdf_base64' not in preview:
+        assert 'render_error' in preview
+        return
+    downloaded = client.get(
+        f"/api/v1/printing/jobs/{created.json()['id']}/preview.pdf",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.reader',
+    )
+    assert downloaded.status_code == 200
+    assert downloaded['Content-Type'] == 'application/pdf'
+    assert downloaded.content[:4] == b'%PDF'
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pdf_sheet_batch_count_repeats_labels_per_row():
+    host, _ = _create_tenants()
+    client = Client()
+    template = client.post(
+        '/api/v1/printing/templates',
+        data=json.dumps(
+            {
+                'name': 'A4 Batch Rows',
+                'template_ref': 'a4/batch-rows',
+                'output_format': 'pdf',
+                'content': 'QR [[content]]',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert template.status_code == 201
+
+    created = client.post(
+        '/api/v1/printing/jobs',
+        data=json.dumps(
+            {
+                'template_ref': 'a4/batch-rows',
+                'output_format': 'pdf',
+                'destination': 'office-printer-1',
+                'payload': {
+                    'labels': ['BATCH-001'],
+                    'pdf_sheet_preset': 'a4-38x21.2',
+                    'batch_count': 5,
+                },
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+    preview = created.json()['gateway_metadata']['render_preview']
+    assert preview['batch_count'] == 5
+    assert preview['label_count'] == 5

--- a/backend/tests/test_tenant_admin_api.py
+++ b/backend/tests/test_tenant_admin_api.py
@@ -15,7 +15,7 @@ def test_tenant_admin_api_can_create_tenant_and_route_requests():
     client = Client()
     created = client.post(
         '/api/v1/tenants',
-        data=json.dumps({'name': 'Tenant A', 'domain': host}),
+        data=json.dumps({'name': f"Tenant {uuid.uuid4().hex[:6]}", 'domain': host}),
         content_type='application/json',
         HTTP_HOST=control_host,
     )
@@ -85,3 +85,41 @@ def test_tenant_create_emits_event_when_configured(monkeypatch):
     assert calls[0]['payload']['correlation_id'] == 'corr-1'
     assert calls[0]['payload']['user_id'] == 'user-1'
     assert calls[1]['payload']['event_type'] == 'audit.tenant.created'
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tenant_services_registry_create_and_list():
+    client = Client()
+    control_host = 'control.example'
+    created_tenant = client.post(
+        '/api/v1/tenants',
+        data=json.dumps({'name': f'Tenant {uuid.uuid4().hex[:6]}', 'domain': f"tenant-{uuid.uuid4().hex[:6]}.example"}),
+        content_type='application/json',
+        HTTP_HOST=control_host,
+    )
+    assert created_tenant.status_code == 201
+    tenant_id = created_tenant.json()['id']
+
+    created_route = client.post(
+        '/api/v1/tenants/services',
+        data=json.dumps(
+            {
+                'tenant_id': tenant_id,
+                'service_key': 'printing',
+                'tenant_slug': 'tenant-alpha',
+                'base_domain': 'platform.example.com',
+                'workspace_path': '/app',
+            }
+        ),
+        content_type='application/json',
+        HTTP_HOST=control_host,
+    )
+    assert created_route.status_code == 201
+    assert created_route.json()['domain'] == 'printing.tenant-alpha.platform.example.com'
+
+    listed = client.get(
+        f'/api/v1/tenants/services?tenant_id={tenant_id}',
+        HTTP_HOST=control_host,
+    )
+    assert listed.status_code == 200
+    assert len(listed.json()['items']) == 1

--- a/backend/tests/test_tenant_isolation.py
+++ b/backend/tests/test_tenant_isolation.py
@@ -5,7 +5,7 @@ from django.test import Client
 from django_tenants.utils import schema_context
 
 from core.models import Project
-from tenants.models import Domain, Tenant
+from tenants.models import Domain, Tenant, TenantServiceRoute
 
 
 @pytest.mark.django_db(transaction=True)
@@ -20,13 +20,15 @@ def test_requests_without_tenant_are_rejected():
 
 @pytest.mark.django_db(transaction=True)
 def test_schema_per_tenant_isolated_data_and_routing():
-    tenant_a = Tenant(schema_name=f't_{uuid.uuid4().hex[:8]}', name='Tenant A')
+    host_a = f"tenanta-{uuid.uuid4().hex[:6]}.example"
+    host_b = f"tenantb-{uuid.uuid4().hex[:6]}.example"
+    tenant_a = Tenant(schema_name=f't_{uuid.uuid4().hex[:8]}', name=f'Tenant A {uuid.uuid4().hex[:6]}')
     tenant_a.save()
-    Domain(domain='tenanta.example', tenant=tenant_a, is_primary=True).save()
+    Domain(domain=host_a, tenant=tenant_a, is_primary=True).save()
 
-    tenant_b = Tenant(schema_name=f't_{uuid.uuid4().hex[:8]}', name='Tenant B')
+    tenant_b = Tenant(schema_name=f't_{uuid.uuid4().hex[:8]}', name=f'Tenant B {uuid.uuid4().hex[:6]}')
     tenant_b.save()
-    Domain(domain='tenantb.example', tenant=tenant_b, is_primary=True).save()
+    Domain(domain=host_b, tenant=tenant_b, is_primary=True).save()
 
     with schema_context(tenant_a.schema_name):
         Project.objects.create(name='A')
@@ -40,6 +42,123 @@ def test_schema_per_tenant_isolated_data_and_routing():
         assert Project.objects.filter(name='B').count() == 0
 
     client = Client()
-    resp = client.get('/', HTTP_HOST='tenanta.example')
+    resp = client.get('/', HTTP_HOST=host_a)
     assert resp.status_code == 200
     assert resp.json()['schema'] == tenant_a.schema_name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_service_route_hostname_resolves_tenant():
+    with schema_context('public'):
+        tenant_slug = f"tenantsvc-{uuid.uuid4().hex[:6]}"
+        base_domain = f"platform-{uuid.uuid4().hex[:6]}.example"
+        domain = f"{tenant_slug}.example"
+        tenant = Tenant(
+            schema_name=f't_{uuid.uuid4().hex[:8]}',
+            name=f'Tenant Service {uuid.uuid4().hex[:6]}',
+        )
+        tenant.save()
+        Domain(domain=domain, tenant=tenant, is_primary=True).save()
+        TenantServiceRoute.objects.create(
+            tenant=tenant,
+            service_key='printing',
+            tenant_slug=tenant_slug,
+            base_domain=base_domain,
+            workspace_path='/app',
+            is_enabled=True,
+        )
+
+    client = Client()
+    routed = client.get('/', HTTP_HOST=f'printing.{tenant_slug}.{base_domain}')
+    assert routed.status_code == 200
+    assert routed.json()['schema'] == tenant.schema_name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_service_route_hostname_renders_user_portal_for_tenant():
+    with schema_context('public'):
+        tenant_slug = f"tenantlab-{uuid.uuid4().hex[:6]}"
+        primary_domain = f"{tenant_slug}.example"
+        tenant = Tenant(
+            schema_name=f't_{uuid.uuid4().hex[:8]}',
+            name=f'Tenant Lab Portal {uuid.uuid4().hex[:6]}',
+        )
+        tenant.save()
+        Domain(domain=primary_domain, tenant=tenant, is_primary=True).save()
+        TenantServiceRoute.objects.create(
+            tenant=tenant,
+            service_key='lab',
+            tenant_slug=tenant_slug,
+            base_domain='edmp.co.tz',
+            workspace_path='/app',
+            is_enabled=True,
+        )
+
+    client = Client()
+    created = client.post(
+        '/api/v1/printing/templates',
+        data='{"name":"E2E Lab Template","template_ref":"lab/e2e","output_format":"pdf","content":"QR [[content]]"}',
+        content_type='application/json',
+        HTTP_HOST=primary_domain,
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert created.status_code == 201
+
+    page = client.get(
+        '/app',
+        HTTP_HOST=f'lab.{tenant_slug}.edmp.co.tz',
+        HTTP_X_USER_ROLES='catalog.editor',
+    )
+    assert page.status_code == 200
+    assert b'User Workspace' in page.content
+    assert b'E2E Lab Template' in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tenant_root_hostname_resolves_via_service_route_slug():
+    with schema_context('public'):
+        tenant_slug = f"tenantroot-{uuid.uuid4().hex[:6]}"
+        tenant = Tenant(
+            schema_name=f't_{uuid.uuid4().hex[:8]}',
+            name=f'Tenant Root {uuid.uuid4().hex[:6]}',
+        )
+        tenant.save()
+        Domain(domain=f'{tenant_slug}.example', tenant=tenant, is_primary=True).save()
+        TenantServiceRoute.objects.create(
+            tenant=tenant,
+            service_key='lab',
+            tenant_slug=tenant_slug,
+            base_domain='edmp.co.tz',
+            workspace_path='/app',
+            is_enabled=True,
+        )
+
+    client = Client()
+    routed = client.get('/', HTTP_HOST=f'{tenant_slug}.edmp.co.tz')
+    assert routed.status_code == 200
+    assert routed.json()['schema'] == tenant.schema_name
+
+
+@pytest.mark.django_db(transaction=True)
+def test_tenant_first_service_hostname_resolves_tenant():
+    with schema_context('public'):
+        tenant_slug = f"tenantfirst-{uuid.uuid4().hex[:6]}"
+        tenant = Tenant(
+            schema_name=f't_{uuid.uuid4().hex[:8]}',
+            name=f'Tenant First {uuid.uuid4().hex[:6]}',
+        )
+        tenant.save()
+        Domain(domain=f'{tenant_slug}.example', tenant=tenant, is_primary=True).save()
+        TenantServiceRoute.objects.create(
+            tenant=tenant,
+            service_key='edcs',
+            tenant_slug=tenant_slug,
+            base_domain='edmp.co.tz',
+            workspace_path='/app',
+            is_enabled=True,
+        )
+
+    client = Client()
+    routed = client.get('/', HTTP_HOST=f'{tenant_slug}.edcs.edmp.co.tz')
+    assert routed.status_code == 200
+    assert routed.json()['schema'] == tenant.schema_name

--- a/backend/tests/test_ui_operations_api.py
+++ b/backend/tests/test_ui_operations_api.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 from django.test import Client
+from django.test.utils import override_settings
 from django_tenants.utils import schema_context
 
 from tenants.models import Domain, Tenant
@@ -178,3 +179,332 @@ def test_ui_operations_role_enforcement_when_enabled(monkeypatch):
         HTTP_X_USER_ROLES="catalog.reader",
     )
     assert allowed.status_code == 200
+
+
+@pytest.mark.django_db(transaction=True)
+def test_ui_operations_html_pages_render():
+    host, _ = _create_tenants()
+    client = Client()
+
+    dashboard = client.get("/ui/operations/dashboard", HTTP_HOST=host)
+    stewardship = client.get("/ui/operations/stewardship", HTTP_HOST=host)
+    orchestration = client.get("/ui/operations/orchestration", HTTP_HOST=host)
+    printing = client.get("/ui/operations/printing", HTTP_HOST=host)
+    agent = client.get("/ui/operations/agent", HTTP_HOST=host)
+
+    assert dashboard.status_code == 200
+    assert stewardship.status_code == 200
+    assert orchestration.status_code == 200
+    assert printing.status_code == 200
+    assert agent.status_code == 200
+    assert b"Skip to content" in dashboard.content
+    assert b"Operations Dashboard" in dashboard.content
+    assert b"Stewardship Workbench" in stewardship.content
+    assert b"Printing Operations" in printing.content
+
+
+@pytest.mark.django_db(transaction=True)
+@override_settings(EDMP_UI_MATERIAL_ENABLED=True)
+def test_ui_operations_html_pages_fallback_when_material_base_missing():
+    host, _ = _create_tenants()
+    client = Client()
+    dashboard = client.get("/ui/operations/dashboard", HTTP_HOST=host)
+    assert dashboard.status_code == 200
+    assert b"EDMP Operations" in dashboard.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_ui_operations_html_filters_apply():
+    host, _ = _create_tenants()
+    client = Client()
+
+    client.post(
+        "/api/v1/stewardship/items",
+        data=json.dumps(
+            {"item_type": "quality_exception", "subject_ref": "asset:critical", "severity": "critical"}
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+    )
+    client.post(
+        "/api/v1/stewardship/items",
+        data=json.dumps(
+            {"item_type": "quality_exception", "subject_ref": "asset:low", "severity": "low"}
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+    )
+
+    filtered = client.get(
+        "/ui/operations/stewardship?severity=critical",
+        HTTP_HOST=host,
+    )
+    assert filtered.status_code == 200
+    assert b"asset:critical" in filtered.content
+    assert b"asset:low" not in filtered.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_ui_action_controls_visibility_by_role(monkeypatch):
+    monkeypatch.setenv("EDMP_ENFORCE_ROLES", "true")
+    host, _ = _create_tenants()
+    client = Client()
+
+    client.post(
+        "/api/v1/stewardship/items",
+        data=json.dumps(
+            {"item_type": "quality_exception", "subject_ref": "asset:role-check", "severity": "high"}
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+
+    admin_view = client.get(
+        "/ui/operations/stewardship",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+    reader_view = client.get(
+        "/ui/operations/stewardship",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.reader",
+    )
+
+    assert admin_view.status_code == 200
+    assert reader_view.status_code == 200
+    assert b'data-ui-action="stewardship"' in admin_view.content
+    assert b'data-ui-action="stewardship"' not in reader_view.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_ui_feedback_banner_renders_from_query_params():
+    host, _ = _create_tenants()
+    client = Client()
+    page = client.get(
+        "/ui/operations/dashboard?ui_message=Action%20completed&ui_error=0",
+        HTTP_HOST=host,
+    )
+    assert page.status_code == 200
+    assert b"Action completed" in page.content
+    assert b"banner ok" in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_stewardship_action_form_fields_render_for_managers(monkeypatch):
+    monkeypatch.setenv("EDMP_ENFORCE_ROLES", "true")
+    host, _ = _create_tenants()
+    client = Client()
+    client.post(
+        "/api/v1/stewardship/items",
+        data=json.dumps(
+            {"item_type": "quality_exception", "subject_ref": "asset:form", "severity": "high"}
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+    page = client.get(
+        "/ui/operations/stewardship",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+    assert page.status_code == 200
+    assert b'data-ui-action-form="stewardship"' in page.content
+    assert b"assignee (for assign)" in page.content
+    assert b"resolution JSON (for resolve)" in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_orchestration_action_form_renders_for_admin():
+    host, _ = _create_tenants()
+    client = Client()
+    project = client.post(
+        "/api/v1/projects",
+        data=json.dumps({"name": "UI Action Project"}),
+        content_type="application/json",
+        HTTP_HOST=host,
+    )
+    ingestion = client.post(
+        "/api/v1/ingestions",
+        data=json.dumps(
+            {"project_id": project.json()["id"], "connector": "dbt", "source": {"processed_entities": 1}}
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+    )
+    workflow = client.post(
+        "/api/v1/orchestration/workflows",
+        data=json.dumps(
+            {"name": "ui-orch-actions", "project_id": project.json()["id"], "steps": [{"step_id": "s1", "ingestion_id": ingestion.json()["id"]}]}
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+    client.post(
+        "/api/v1/orchestration/runs",
+        data=json.dumps({"workflow_id": workflow.json()["id"]}),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    page = client.get(
+        "/ui/operations/orchestration",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+    assert page.status_code == 200
+    assert b'data-ui-action-form="orchestration"' in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_agent_action_form_renders_with_input_fields():
+    host, _ = _create_tenants()
+    client = Client()
+    client.post(
+        "/api/v1/agent/runs",
+        data=json.dumps({"prompt": "project:p monitor", "allowed_tools": ["quality.read"], "start_now": True}),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    page = client.get(
+        "/ui/operations/agent",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    assert page.status_code == 200
+    assert b'data-ui-action-form="agent"' in page.content
+    assert b"error message (for fail)" in page.content
+    assert b"output JSON (for complete)" in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_printing_page_renders_jobs_and_gateways():
+    host, _ = _create_tenants()
+    client = Client()
+    client.post(
+        "/api/v1/printing/templates",
+        data=json.dumps(
+            {
+                "name": "Shipping Label",
+                "template_ref": "label/shipping-ui",
+                "output_format": "pdf",
+                "sample_payload": {"order_id": "42"},
+            }
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    client.post(
+        "/api/v1/printing/jobs",
+        data=json.dumps(
+            {
+                "template_ref": "label/shipping-ui",
+                "destination": "printer-a",
+                "output_format": "pdf",
+                "payload": {"order_id": "42"},
+            }
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    client.post(
+        "/api/v1/printing/gateways",
+        data=json.dumps(
+            {
+                "gateway_ref": "gw-ui-test",
+                "display_name": "Gateway UI Test",
+                "status": "online",
+            }
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin",
+    )
+    page = client.get(
+        "/ui/operations/printing",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="policy.admin,catalog.editor",
+    )
+    assert page.status_code == 200
+    assert b"Shipping Label" in page.content
+    assert b"Run test print" in page.content
+    assert b"Define print template" in page.content
+    assert b"Gateway UI Test" in page.content
+    assert b'data-ui-action-form="print-job"' in page.content
+    assert b'data-ui-action-form="print-gateway"' in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_user_portal_dashboard_renders_test_print_action():
+    host, _ = _create_tenants()
+    client = Client()
+    client.post(
+        "/api/v1/printing/templates",
+        data=json.dumps(
+            {
+                "name": "Portal Label",
+                "template_ref": "label/portal",
+                "output_format": "pdf",
+                "sample_payload": {"sample": True},
+            }
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    client.post(
+        "/api/v1/printing/gateways",
+        data=json.dumps(
+            {
+                "gateway_ref": "printer-portal-1",
+                "display_name": "Portal Printer",
+                "status": "online",
+            }
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    page = client.get(
+        "/app",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+        HTTP_X_USER_ID="user-portal-1",
+    )
+    assert page.status_code == 200
+    assert b"User Workspace" in page.content
+    assert b"Test print" in page.content
+    assert b'data-user-action="test-print"' in page.content
+    assert b'data-user-action="create-template"' in page.content
+    assert b'data-user-action="create-printer"' in page.content
+    assert b'data-user-action="template-preview"' in page.content
+    assert b'data-user-action="printer-status-update"' in page.content
+    assert b"participant prefix" in page.content
+    assert b"range start" in page.content
+    assert b"range end" in page.content
+    assert b"Serial position" in page.content
+    assert b"label variants" in page.content
+    assert b"PDF sheet preset" in page.content
+    assert b"labels (optional, one per line)" in page.content
+    assert b"Signed in as:" in page.content
+    assert b"user-portal-1" in page.content
+    assert b"catalog.editor" in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_user_portal_dashboard_includes_default_print_templates():
+    host, _ = _create_tenants()
+    client = Client()
+    page = client.get(
+        "/app",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="catalog.editor",
+    )
+    assert page.status_code == 200
+    assert b"Zebra QR Label (9-pack ready)" in page.content
+    assert b"A4 QR Sheet 65-up (38.1x21.2mm)" in page.content

--- a/docs/edcs.md
+++ b/docs/edcs.md
@@ -1,0 +1,36 @@
+# Electronic Data Capture System (EDCS) — Specification Placeholder
+
+Status: Placeholder for future specification.
+
+## Purpose
+
+This document will define the tenant-aware EDCS system exposed at:
+
+- `[tenant].[edcs].edmp.co.tz`
+
+## Scope (to be detailed)
+
+- Study/form design and versioning
+- Data capture and validation workflow
+- Submission, review, and correction lifecycle
+- User roles and field-level access controls
+- Operational reporting requirements
+
+## Integration contracts (to be detailed)
+
+- Shared identity and tenant context from EDMP platform
+- Interoperability with ODK/REDCap-related platform services
+- Eventing, exports, and downstream data product hooks
+
+## Non-functional requirements (to be detailed)
+
+- Availability and performance targets
+- Data residency and retention requirements
+- Security, audit, and observability requirements
+
+## Open questions
+
+- Form metadata model and API contracts
+- Offline/online behavior and sync strategy
+- Migration strategy for existing tenant data capture flows
+

--- a/docs/lab-lims.md
+++ b/docs/lab-lims.md
@@ -1,0 +1,36 @@
+# Research Lab Information Management System (LAB) — Specification Placeholder
+
+Status: Placeholder for future specification.
+
+## Purpose
+
+This document will define the tenant-aware LAB system exposed at:
+
+- `[tenant].[lab].edmp.co.tz`
+
+## Scope (to be detailed)
+
+- Laboratory workflow modules
+- Sample lifecycle and chain-of-custody
+- Instrument/result integrations
+- Role and permission model
+- Audit and compliance controls
+
+## Integration contracts (to be detailed)
+
+- Shared identity and tenant context from EDMP platform
+- Eventing and API integrations with workspace services
+- Printing and document management touchpoints
+
+## Non-functional requirements (to be detailed)
+
+- Availability and performance targets
+- Data residency and retention requirements
+- Security and observability requirements
+
+## Open questions
+
+- Detailed domain model and workflow states
+- External systems and protocol support
+- Migration and rollout strategy per tenant
+

--- a/docs/platform-services.md
+++ b/docs/platform-services.md
@@ -62,3 +62,27 @@ helm upgrade --install edmp-platform deploy/helm/edmp-platform -n edmp --create-
 ## Operational response
 
 For operator first-response procedures and incident checkpoints, see [operations runbooks](operations-runbooks.md).
+
+## Portal and domain setup runbook (baseline)
+
+Primary domain topology under `edmp.co.tz`:
+
+* Shared platform services on designated subdomains (`odk`, `odkx`, `redcap`, `rapidsms`, `onlyoffice`).
+* Tenant workspace entry at `[tenant].edmp.co.tz`.
+* Tenant vertical systems at `[tenant].[lab].edmp.co.tz` and `[tenant].[edcs].edmp.co.tz`.
+
+Current backend routing baseline:
+
+* Explicit domain match via tenant domain records.
+* Tenant service-route registry (`/api/v1/tenants/services`) for enabled service mappings.
+* Host fallback resolver supports:
+  * `service.tenant.base-domain`
+  * `tenant.service.base-domain`
+  * `tenant.base-domain` (resolved via tenant_slug on enabled service routes)
+
+Operator checklist:
+
+1. Set `EDMP_BASE_DOMAIN=edmp.co.tz` in environment.
+2. Create tenant and primary domain.
+3. Register tenant service routes for enabled tenant systems (`lab`, `edcs`, workspace-linked services).
+4. Validate host resolution with smoke checks on `/` and `/app` for each intended domain pattern.

--- a/docs/printing.md
+++ b/docs/printing.md
@@ -59,3 +59,71 @@ Events:
 * `print.retrying`
 * `print.completed`
 * `print.failed`
+
+## Standardized rendering stack (selected)
+
+To support both Zebra and A4 label workflows with one predictable toolchain, EDMP standardizes on:
+
+* `qrcode` for QR payload generation
+* `reportlab` for PDF drawing/composition
+* `pylabels` for sheet-label layouting (A4 labels-per-sheet scenarios)
+
+Target usage by format:
+
+* `zpl`: gateway receives ZPL-compatible payload/templates for Zebra-class printers
+* `pdf`: backend generates A4 label-sheet PDF output (including 38mm x 21.2mm presets) for office printers
+
+Current scaffold implementation includes a renderer abstraction (`core/printing_renderers.py`) that produces normalized preview output for `zpl` and `pdf` templates before dispatch.
+
+### Zebra participant batch labels
+
+`zpl` jobs now accept `payload.labels` as an array of label strings.  
+When provided, preview rendering expands one ZPL block per label and stores `label_count` in `gateway_metadata.render_preview`.
+
+Default participant-batch mode is also supported for Zebra jobs:
+* provide `payload.participant_prefix`, `payload.range_start`, and `payload.range_end`
+* EDMP auto-generates 9 labels per participant ID (`base`, `BLD-6mls`, `BLD-4mls`, `BLD-2mls`, `PLM1`, `PLM2`, `BLD-RNA`, `NA1`, `NA2`)
+* optional `payload.serial_position = "at_end"` moves serial to the tail of each label
+* optional `payload.label_suffixes` lets you override variants (use `"base"` for the root label)
+
+For A4 sheet PDF generation:
+* provide `payload.labels` as label lines
+* optional `payload.pdf_sheet_preset` (currently `a4-38x21.2`)
+* preset `a4-38x21.2` uses a fixed 65-up grid (5 x 13) with 38.1mm x 21.2mm labels and symmetric page margins
+* optional `payload.batch_count` repeats each input label N times (for example `5` fills one row with identical labels)
+* renderer composes QR+text labels per sheet and includes `sheet_preset` + `label_count` in preview metadata
+* download preview PDF via `GET /api/v1/printing/jobs/<job_id>/preview.pdf` when preview contains inline `pdf_base64`
+
+Default templates are provided for user selection in `/app`:
+* `zebra/participant-batch` (Zebra QR 9-pack workflow)
+* `a4/65-up` (A4 QR sheet workflow)
+
+For deployments that want persisted DB records, load fixture seed data:
+
+```bash
+cd backend
+python manage.py loaddata core/fixtures/printing_templates.json
+```
+
+Example payload:
+
+```json
+{
+  "template_ref": "zebra/participant-batch",
+  "output_format": "zpl",
+  "destination": "zebra-printer-1",
+  "payload": {
+    "labels": [
+      "MLTP2-MBY-KWJ-001",
+      "MLTP2-MBY-KWJ-001-BLD-6mls",
+      "MLTP2-MBY-KWJ-001-BLD-4mls",
+      "MLTP2-MBY-KWJ-001-BLD-2mls",
+      "MLTP2-MBY-KWJ-001-PLM1",
+      "MLTP2-MBY-KWJ-001-PLM2",
+      "MLTP2-MBY-KWJ-001-BLD-RNA",
+      "MLTP2-MBY-KWJ-001-NA1",
+      "MLTP2-MBY-KWJ-001-NA2"
+    ]
+  }
+}
+```

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -76,11 +76,18 @@ This repository is an intentionally small scaffold. This roadmap lists the next 
 
 ## Near-term (next)
 
-No additional near-term items are currently queued in this scaffold.
+1. **End-user workspace UI baseline**: add tenant-facing pages for print setup, template catalog, and test-print submission with clear non-operator UX flows.
+2. **Wildcard tenant domain routing**: support base platform domain + service-aware tenant subdomains (`<service>.<tenant>.<base-domain>`) in tenant resolution and host validation.
+3. **Tenant service-entry registry**: define how requested services map to tenant subdomains and route users to the right workspace entrypoint.
+4. **End-user auth/session UX**: deliver login, tenant switch, and permission-aware navigation patterns for non-operations users.
+5. **Portal acceptance and regression coverage**: add tests for tenant isolation, role visibility, and wildcard-host routing behavior.
 
 ## Mid-term
 
-No additional mid-term items are currently queued in this scaffold.
+1. **Self-service onboarding flow**: tenant admin onboarding for service activation, domain assignment visibility, and first-use checklist.
+2. **Service-specific workspace shells**: shared design system with service modules (printing, governance, collaboration, etc.) under tenant subdomains.
+3. **Tenant LAB LIMS system specification**: define detailed product/API/domain model for `[tenant].[lab].edmp.co.tz` (see `docs/lab-lims.md`).
+4. **Tenant EDCS system specification**: define detailed product/API/domain model for `[tenant].[edcs].edmp.co.tz` (see `docs/edcs.md`).
 
 ## Out of scope for this scaffold (yet)
 

--- a/docs/workflow-ui.md
+++ b/docs/workflow-ui.md
@@ -154,3 +154,16 @@ To enable UI implementation with a stable backend contract, EDMP now provides UI
   * supports optional `project_id` filtering
 
 This keeps UI rendering concerns decoupled from domain mutation APIs while preserving server-side role enforcement.
+
+## django-material implementation baseline (new)
+
+To deliver modern SaaS-style operations screens (Slack/Google Drive-like density and navigation) without replacing the backend API contract:
+
+* Keep existing `/api/v1/ui/operations/*` endpoints as the source of truth.
+* Add server-rendered HTML routes under `/ui/operations/*` that consume the same payloads.
+* Use `django-material` as an optional presentation layer (`EDMP_UI_MATERIAL_ENABLED=true`) with a safe fallback template for environments where the package is not enabled.
+* Enforce the same role checks and tenant isolation on HTML routes as API routes.
+* Include modern UX baselines by default: summary-first cards, filter toolbars, accessible skip-link/focus behavior, and responsive navigation.
+* Provide inline action controls for operational transitions and show consistent success/error feedback banners after action execution.
+
+This enables incremental rollout: API-first remains stable while UI pages mature independently.

--- a/scripts/local_preview.sh
+++ b/scripts/local_preview.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BACKEND_DIR="$ROOT_DIR/backend"
+PYTHON_BIN="$ROOT_DIR/.venv/bin/python"
+
+export POSTGRES_DB="${POSTGRES_DB:-edmp_test}"
+export POSTGRES_USER="${POSTGRES_USER:-edmp}"
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-edmp}"
+export POSTGRES_HOST="${POSTGRES_HOST:-localhost}"
+export POSTGRES_PORT="${POSTGRES_PORT:-5432}"
+export DJANGO_ALLOWED_HOSTS="${DJANGO_ALLOWED_HOSTS:-localhost,127.0.0.1}"
+export EDMP_UI_MATERIAL_ENABLED="${EDMP_UI_MATERIAL_ENABLED:-false}"
+export EDMP_PREVIEW_PORT="${EDMP_PREVIEW_PORT:-8000}"
+
+usage() {
+  echo "Usage: $0 [prep|serve|up|down|status]"
+}
+
+ensure_venv() {
+  if [[ ! -x "$PYTHON_BIN" ]]; then
+    python3 -m venv "$ROOT_DIR/.venv"
+    "$PYTHON_BIN" -m pip install -q --upgrade pip
+    "$PYTHON_BIN" -m pip install -q -r "$BACKEND_DIR/requirements-dev.txt"
+  fi
+}
+
+prep() {
+  cd "$ROOT_DIR"
+  docker compose up -d --wait postgres rabbitmq
+  ensure_venv
+  cd "$BACKEND_DIR"
+  "$PYTHON_BIN" manage.py migrate_schemas --shared --noinput
+  "$PYTHON_BIN" manage.py migrate_schemas --tenant --noinput
+  "$PYTHON_BIN" manage.py shell -c "from tenants.models import Tenant,Domain; t,_=Tenant.objects.get_or_create(schema_name='local', defaults={'name':'Local Tenant'}); Domain.objects.get_or_create(domain='localhost', tenant=t, defaults={'is_primary':True})"
+}
+
+serve() {
+  local existing_pid
+  existing_pid="$(ss -ltnp "( sport = :${EDMP_PREVIEW_PORT} )" 2>/dev/null | sed -n 's/.*pid=\([0-9]\+\).*/\1/p' | head -n1 || true)"
+  if [[ -n "${existing_pid}" ]]; then
+    echo "Port ${EDMP_PREVIEW_PORT} is already in use by PID ${existing_pid}."
+    echo "Stop it with: kill ${existing_pid}"
+    echo "Or run on another port: EDMP_PREVIEW_PORT=8001 $0 serve"
+    exit 1
+  fi
+  cd "$BACKEND_DIR"
+  "$PYTHON_BIN" manage.py runserver "0.0.0.0:${EDMP_PREVIEW_PORT}"
+}
+
+command="${1:-up}"
+case "$command" in
+  prep)
+    prep
+    ;;
+  serve)
+    serve
+    ;;
+  up)
+    prep
+    serve
+    ;;
+  down)
+    cd "$ROOT_DIR"
+    docker compose down
+    ;;
+  status)
+    cd "$ROOT_DIR"
+    docker compose ps
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary\n- add default selectable Zebra/A4 templates plus deployment fixture seeds\n- improve A4 65-up printing behavior and portal prefill UX\n- add LAB/EDCS placeholder specs and documentation links\n- expand tenant host resolution for tenant/service domain patterns with tests\n\n## Validation\n- pytest -q tests/test_printing_api.py -k "pdf_sheet_preview_with_labels_and_preset or a4_65_labels_preview_downloadable_when_available or pdf_sheet_batch_count_repeats_labels_per_row" --reuse-db\n- pytest -q tests/test_ui_operations_api.py -k "user_portal_dashboard_renders_test_print_action or user_portal_dashboard_includes_default_print_templates" --reuse-db\n- pytest -q tests/test_tenant_isolation.py -k "service_route_hostname_resolves_tenant or service_route_hostname_renders_user_portal_for_tenant or tenant_root_hostname_resolves_via_service_route_slug or tenant_first_service_hostname_resolves_tenant" --reuse-db\n- pytest -q tests/test_tenant_admin_api.py -k "tenant_services_registry_create_and_list" --reuse-db