### PR TITLE
feat: integrate spec-kit workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/delivery-work-item.md
+++ b/.github/ISSUE_TEMPLATE/delivery-work-item.md
@@ -10,6 +10,13 @@ assignees: ""
 
 Describe the problem and expected user/platform outcome.
 
+## Spec Kit artifacts
+
+- Spec path:
+- Plan path:
+- Tasks path:
+- Generated with: `python .github/scripts/spec_kit_workflow.py issue-body specs/<feature-dir>`
+
 ## Deliverables
 
 - [ ] Deliverable 1
@@ -32,6 +39,7 @@ Describe the problem and expected user/platform outcome.
 
 - Roadmap item:
 - Design docs:
+- Spec bundle:
 
 ## Handoff contract (required updates during execution)
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,13 @@
 
 Describe what this PR changes and why.
 
+## Spec Kit artifacts
+
+- [ ] Spec path recorded.
+- [ ] Plan path recorded.
+- [ ] Tasks path recorded.
+- [ ] PR body refreshed from `python .github/scripts/spec_kit_workflow.py pr-body specs/<feature-dir>`.
+
 ## Issue contract
 
 - [ ] Linked execution issue includes Objective, Deliverables, Acceptance Criteria, Dependencies, and References.

--- a/.github/scripts/spec_kit_workflow.py
+++ b/.github/scripts/spec_kit_workflow.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(os.environ.get("SPEC_KIT_WORKFLOW_ROOT", Path(__file__).resolve().parents[2])).resolve()
+TASK_RE = re.compile(r"^- \[(?P<done>[ xX])\]\s+(?P<body>.+)$")
+
+
+@dataclass(frozen=True)
+class FeatureBundle:
+    feature_dir: Path
+    spec_path: Path
+    plan_path: Path
+    tasks_path: Path
+
+
+def resolve_feature_dir(feature: str) -> Path:
+    path = Path(feature)
+    if not path.is_absolute():
+        path = (REPO_ROOT / path).resolve()
+    return path
+
+
+def load_bundle(feature: str) -> FeatureBundle:
+    feature_dir = resolve_feature_dir(feature)
+    return FeatureBundle(
+        feature_dir=feature_dir,
+        spec_path=feature_dir / "spec.md",
+        plan_path=feature_dir / "plan.md",
+        tasks_path=feature_dir / "tasks.md",
+    )
+
+
+def ensure_exists(path: Path) -> None:
+    if not path.exists():
+        raise FileNotFoundError(path)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def relative_to_repo(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(resolved)
+
+
+def normalize_heading(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def extract_title(text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return "Untitled feature"
+
+
+def clean_feature_title(title: str) -> str:
+    cleaned = re.sub(r"^Feature Specification:\s*", "", title).strip()
+    return cleaned or title.strip()
+
+
+def extract_section(text: str, *candidate_titles: str) -> str:
+    wanted = {normalize_heading(item) for item in candidate_titles}
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        match = re.match(r"^(#{1,6})\s+(.*)$", line)
+        if not match:
+            continue
+        heading_level = len(match.group(1))
+        heading_title = normalize_heading(match.group(2))
+        if heading_title not in wanted:
+            continue
+        collected: list[str] = []
+        for body_line in lines[index + 1 :]:
+            body_match = re.match(r"^(#{1,6})\s+(.*)$", body_line)
+            if body_match and len(body_match.group(1)) <= heading_level:
+                break
+            collected.append(body_line)
+        return "\n".join(collected).strip()
+    return ""
+
+
+def first_meaningful_line(text: str) -> str:
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("**"):
+            return stripped
+    return ""
+
+
+def parse_tasks(text: str) -> tuple[int, int, list[str]]:
+    total = 0
+    done = 0
+    previews: list[str] = []
+    for line in text.splitlines():
+        match = TASK_RE.match(line)
+        if not match:
+            continue
+        total += 1
+        if match.group("done").lower() == "x":
+            done += 1
+        body = re.sub(r"\[[^\]]+\]\s*", "", match.group("body")).strip()
+        previews.append(body)
+    return total, done, previews
+
+
+def bulletize(section_text: str, *, fallback: str) -> list[str]:
+    items = [
+        line.strip()[2:].strip()
+        for line in section_text.splitlines()
+        if line.strip().startswith("- ")
+    ]
+    if items:
+        return items
+    first_line = first_meaningful_line(section_text)
+    if first_line:
+        return [first_line]
+    return [fallback]
+
+
+def build_issue_body(feature: str) -> str:
+    bundle = load_bundle(feature)
+    ensure_exists(bundle.spec_path)
+    ensure_exists(bundle.plan_path)
+    ensure_exists(bundle.tasks_path)
+
+    spec_text = read_text(bundle.spec_path)
+    plan_text = read_text(bundle.plan_path)
+    tasks_text = read_text(bundle.tasks_path)
+
+    title = clean_feature_title(extract_title(spec_text))
+    summary = extract_section(plan_text, "Summary")
+    success = extract_section(spec_text, "Success Criteria", "Measurable Outcomes")
+    delivery = extract_section(spec_text, "Delivery Mapping")
+    repository_context = extract_section(spec_text, "Repository Context")
+    total_tasks, done_tasks, previews = parse_tasks(tasks_text)
+
+    deliverables = previews[:5] or ["Convert the approved plan into implementation-sized tasks."]
+    acceptance_items = bulletize(
+        success,
+        fallback="Feature behavior matches the approved spec and plan.",
+    )
+    reference_items = [
+        f"`{relative_to_repo(bundle.spec_path)}`",
+        f"`{relative_to_repo(bundle.plan_path)}`",
+        f"`{relative_to_repo(bundle.tasks_path)}`",
+    ]
+    if repository_context:
+        reference_items.extend(bulletize(repository_context, fallback="Repository context captured in the spec."))
+
+    objective = first_meaningful_line(summary) or f"Implement `{title}` from the approved spec-kit bundle."
+    dependency_items = bulletize(delivery, fallback="Depends on: None")
+
+    lines = [
+        f"## Objective",
+        "",
+        objective,
+        "",
+        "## Spec Kit artifacts",
+        "",
+        f"- Spec: `{relative_to_repo(bundle.spec_path)}`",
+        f"- Plan: `{relative_to_repo(bundle.plan_path)}`",
+        f"- Tasks: `{relative_to_repo(bundle.tasks_path)}`",
+        f"- Task progress at issue creation: {done_tasks}/{total_tasks} complete",
+        "",
+        "## Deliverables",
+        "",
+    ]
+    lines.extend(f"- [ ] {item}" for item in deliverables)
+    lines.extend(
+        [
+            "",
+            "## Acceptance Criteria",
+            "",
+        ]
+    )
+    lines.extend(f"- [ ] {item}" for item in acceptance_items)
+    lines.extend(
+        [
+            "",
+            "## Dependencies",
+            "",
+        ]
+    )
+    lines.extend(f"- {item}" for item in dependency_items)
+    lines.extend(
+        [
+            "",
+            "## References",
+            "",
+        ]
+    )
+    lines.extend(f"- {item}" for item in reference_items)
+    lines.extend(
+        [
+            "",
+            "## Handoff contract (required updates during execution)",
+            "",
+            f"- Scope boundary: `{title}`",
+            "- Changed files:",
+            "- Risk notes:",
+            "- Done/blocker state:",
+        ]
+    )
+    return "\n".join(lines).strip() + "\n"
+
+
+def build_pr_body(feature: str, issue_number: str | None = None) -> str:
+    bundle = load_bundle(feature)
+    ensure_exists(bundle.spec_path)
+    ensure_exists(bundle.plan_path)
+    ensure_exists(bundle.tasks_path)
+
+    spec_text = read_text(bundle.spec_path)
+    plan_text = read_text(bundle.plan_path)
+    tasks_text = read_text(bundle.tasks_path)
+
+    title = clean_feature_title(extract_title(spec_text))
+    summary = extract_section(plan_text, "Summary")
+    validation = bulletize(
+        extract_section(plan_text, "Planned Validation"),
+        fallback="Run targeted validation and the repository merge gate.",
+    )
+    total_tasks, done_tasks, _ = parse_tasks(tasks_text)
+
+    issue_line = f"- [ ] Linked issue: #{issue_number}" if issue_number else "- [ ] Linked issue:"
+    summary_line = first_meaningful_line(summary) or f"This PR implements `{title}` from the approved spec-kit bundle."
+
+    lines = [
+        "## Summary",
+        "",
+        summary_line,
+        "",
+        "## Spec Kit artifacts",
+        "",
+        f"- Spec: `{relative_to_repo(bundle.spec_path)}`",
+        f"- Plan: `{relative_to_repo(bundle.plan_path)}`",
+        f"- Tasks: `{relative_to_repo(bundle.tasks_path)}`",
+        f"- Task progress: {done_tasks}/{total_tasks} complete",
+        issue_line,
+        "",
+        "## Issue contract",
+        "",
+        "- [ ] Linked execution issue includes Objective, Deliverables, Acceptance Criteria, Dependencies, and References.",
+        "- [ ] Scope boundary for this PR is explicit and matches the issue deliverables.",
+        "",
+        "## Handoff contract",
+        "",
+        "- [ ] Changed files and risk notes are captured in the PR description.",
+        "- [ ] Done/blocker state is explicit (no implicit follow-up gaps).",
+        "- [ ] Spec bundle was updated first if scope changed during implementation.",
+        "",
+        "## Validation",
+        "",
+    ]
+    lines.extend(f"- [ ] {item}" for item in validation)
+    return "\n".join(lines).strip() + "\n"
+
+
+def build_summary(feature: str) -> dict[str, object]:
+    bundle = load_bundle(feature)
+    ensure_exists(bundle.spec_path)
+    summary: dict[str, object] = {
+        "feature_dir": relative_to_repo(bundle.feature_dir),
+        "spec": relative_to_repo(bundle.spec_path),
+        "title": clean_feature_title(extract_title(read_text(bundle.spec_path))),
+    }
+    if bundle.plan_path.exists():
+        summary["plan"] = relative_to_repo(bundle.plan_path)
+    if bundle.tasks_path.exists():
+        summary["tasks"] = relative_to_repo(bundle.tasks_path)
+        total_tasks, done_tasks, previews = parse_tasks(read_text(bundle.tasks_path))
+        summary["task_counts"] = {"total": total_tasks, "done": done_tasks}
+        summary["task_preview"] = previews[:5]
+    return summary
+
+
+def validate(feature: str) -> list[str]:
+    bundle = load_bundle(feature)
+    errors: list[str] = []
+    if not bundle.feature_dir.exists():
+        errors.append(f"feature directory does not exist: {bundle.feature_dir}")
+        return errors
+    for path in (bundle.spec_path, bundle.plan_path, bundle.tasks_path):
+        if not path.exists():
+            errors.append(f"missing required file: {relative_to_repo(path)}")
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Bridge spec-kit feature bundles into GitHub issue and PR workflows.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_parser = subparsers.add_parser("validate", help="Validate that a feature directory has the required spec-kit files.")
+    validate_parser.add_argument("feature")
+
+    issue_parser = subparsers.add_parser("issue-body", help="Render a GitHub issue body from a feature bundle.")
+    issue_parser.add_argument("feature")
+
+    pr_parser = subparsers.add_parser("pr-body", help="Render a GitHub PR body from a feature bundle.")
+    pr_parser.add_argument("feature")
+    pr_parser.add_argument("--issue-number")
+
+    summary_parser = subparsers.add_parser("summary", help="Emit a JSON summary for a feature bundle.")
+    summary_parser.add_argument("feature")
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "validate":
+        errors = validate(args.feature)
+        if errors:
+            for item in errors:
+                print(item)
+            return 1
+        print("Feature bundle is valid.")
+        return 0
+
+    if args.command == "issue-body":
+        print(build_issue_body(args.feature), end="")
+        return 0
+
+    if args.command == "pr-body":
+        print(build_pr_body(args.feature, issue_number=args.issue_number), end="")
+        return 0
+
+    if args.command == "summary":
+        print(json.dumps(build_summary(args.feature), indent=2, sort_keys=True))
+        return 0
+
+    parser.error(f"unknown command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.specify/constitution.md
+++ b/.specify/constitution.md
@@ -1,0 +1,48 @@
+# Mtafiti Constitution
+
+## Core Principles
+
+### I. Specifications Are the Source of Truth
+All substantial delivery work MUST begin with `spec-kit` artifacts under `specs/<feature>/`.
+The committed specification, implementation plan, and task list define the intended behavior, scope boundaries, and acceptance checks.
+GitHub issues, branches, PR descriptions, SQL todos, and implementation notes MUST derive from those artifacts instead of becoming competing sources of truth.
+
+### II. Tenant-Safe, Service-Aware Design
+Every change MUST preserve schema-per-tenant isolation, service-aware routing, and explicit tenant context propagation.
+Specifications and plans MUST call out tenant boundaries, service host impacts, and any migration or background-task implications before implementation starts.
+
+### III. Knowledge-Backed Engineering
+Specifications and plans MUST cite relevant repository design docs, knowledge-graph artifacts, local skills, and Context Hub lookups for external APIs when they materially affect implementation quality.
+Agents should prefer verified repository knowledge and retrieved framework documentation over assumptions.
+
+### IV. End-to-End Verification Is Mandatory
+No work item is complete until the declared acceptance criteria, targeted validation, and repository merge gates pass.
+Plans MUST name the concrete validation commands, and tasks MUST preserve an implement -> verify -> fix -> re-verify flow before PR creation.
+
+### V. Traceable GitHub Delivery
+Each execution slice MUST map cleanly from spec -> plan -> tasks -> issue -> branch -> PR -> squash merge.
+Branch names MUST remain Git-safe Conventional Commit slugs such as `feat/lims-permissions`, even when a spec directory uses a numeric `spec-kit` feature identifier.
+
+## Platform Constraints
+
+- Primary stack: Django, django-tenants, Celery, PostgreSQL, RabbitMQ, Viewflow, django-material.
+- Service boundaries and tenant routing MUST remain aligned with `TenantServiceRoute` and shared host conventions.
+- Knowledge graph artifacts under `analysis/`, `knowledge_graph/`, `skills/`, and `framework_knowledge/` are deterministic repository outputs and MUST be refreshed when affected.
+- External API usage SHOULD be grounded in Context Hub lookups when the repository does not already contain authoritative usage patterns.
+
+## Development Workflow
+
+1. Ratify or update this constitution when project rules change.
+2. Create or refine `specs/<feature>/spec.md` with `/speckit.specify`.
+3. Produce `plan.md` plus supporting design artifacts with `/speckit.plan`.
+4. Produce `tasks.md` with `/speckit.tasks`.
+5. Generate or refresh GitHub issue and PR bodies from the spec bundle using `.github/scripts/spec_kit_workflow.py`.
+6. Mirror executable work into SQL todos and issue tracking.
+7. Implement on a scoped branch, validate, open a PR, and squash merge after review.
+
+## Governance
+
+This constitution supersedes older ad hoc workflow notes when conflicts arise.
+Amendments MUST be reviewed in Git, explain the reason for change, and update dependent workflow docs or templates in the same PR.
+
+**Version**: 1.0.0 | **Ratified**: 2026-03-19 | **Last Amended**: 2026-03-19

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -1,0 +1,84 @@
+# Implementation Plan: [FEATURE]
+
+**Feature ID**: `[###-feature-name]` | **Branch**: `[type/slug-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+## Summary
+
+[Primary requirement, intended outcome, and implementation approach]
+
+## Technical Context
+
+**Language/Version**: [e.g. Python 3.12]  
+**Primary Dependencies**: [e.g. Django, Viewflow, Celery]  
+**Storage**: [e.g. PostgreSQL, N/A]  
+**Testing**: [e.g. pytest, manage.py check, local_fast_feedback]  
+**Target Platform**: [e.g. Linux server, tenant-aware Django app]  
+**Project Type**: [e.g. multi-tenant web platform]  
+**Performance Goals**: [domain-specific goals or N/A]  
+**Constraints**: [tenant safety, routing, UX, compliance, etc.]  
+**Scale/Scope**: [expected blast radius]
+
+## Constitution Check
+
+- [ ] Specifications remain the source of truth for the slice.
+- [ ] Tenant and service routing impacts are identified.
+- [ ] Knowledge graph / skill / Context Hub inputs are captured where needed.
+- [ ] Validation commands and merge gates are defined.
+- [ ] Issue, branch, and PR mapping are consistent with the spec.
+
+## Research & Knowledge Inputs
+
+### Repository Evidence
+
+- [docs, code paths, checkpoints, or prior PRs]
+
+### Knowledge Graph / Skills
+
+- [relevant nodes, generated skills, or framework knowledge files]
+
+### Context Hub Lookups
+
+- [e.g. `chub get django/forms`, or `Not required`]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+[List the concrete repository paths touched by this feature]
+```
+
+## Delivery Mapping
+
+- **Issue title**: [planned GitHub issue title]
+- **Issue generation command**: `python .github/scripts/spec_kit_workflow.py issue-body specs/[###-feature-name]`
+- **PR generation command**: `python .github/scripts/spec_kit_workflow.py pr-body specs/[###-feature-name]`
+- **Branch naming**: [e.g. `feat/spec-kit-workflow`]
+- **Execution slices**: [one issue or multiple issue-sized slices]
+- **Dependencies**: [Depends on / Blocks / None]
+
+## Planned Validation
+
+- `python .github/scripts/spec_kit_workflow.py validate specs/[###-feature-name]`
+- [targeted validation commands]
+- `.github/scripts/local_fast_feedback.sh --full-gate`
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g. cross-service edit] | [reason] | [why smaller scope was insufficient] |

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -1,0 +1,97 @@
+# Feature Specification: [FEATURE NAME]
+
+**Feature ID**: `[###-feature-name]`  
+**Execution Branch**: `[type/slug-name]`  
+**Created**: [DATE]  
+**Status**: Draft  
+**Input**: User description: "$ARGUMENTS"
+
+## Repository Context *(mandatory)*
+
+- **Service area**: [e.g. core, lims, edcs, printing]
+- **Affected code paths**: [e.g. `src/lims/`, `src/core/`, `.github/scripts/`]
+- **Related design docs**: [e.g. `docs/architecture.md`, `docs/lab-lims.md`]
+- **Knowledge graph / skills evidence**: [relevant nodes, skills, or generated artifacts]
+- **External API lookup needs**: [Context Hub lookups required, or `None`]
+- **Related issues / PRs**: [existing GitHub references, or `None`]
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - [Brief Title] (Priority: P1)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+2. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 2 - [Brief Title] (Priority: P2)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+---
+
+### User Story 3 - [Brief Title] (Priority: P3)
+
+[Describe this user journey in plain language]
+
+**Why this priority**: [Explain the value and why it has this priority level]
+
+**Independent Test**: [Describe how this can be tested independently]
+
+**Acceptance Scenarios**:
+
+1. **Given** [initial state], **When** [action], **Then** [expected outcome]
+
+## Edge Cases
+
+- What happens when [boundary condition]?
+- How does the system handle [error scenario]?
+- What tenant, permission, or service-routing boundary must remain intact?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST [specific capability]
+- **FR-002**: System MUST [specific capability]
+- **FR-003**: Users MUST be able to [key interaction]
+- **FR-004**: System MUST preserve [tenant, routing, audit, or data invariant]
+
+### Non-Goals
+
+- [Explicitly out-of-scope item]
+- [Explicitly deferred item]
+
+### Key Entities *(include if feature involves data)*
+
+- **[Entity 1]**: [What it represents and why it matters]
+- **[Entity 2]**: [What it represents and its relationships]
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: [Measurable, technology-agnostic outcome]
+- **SC-002**: [Measurable, technology-agnostic outcome]
+- **SC-003**: [Operator, UX, or delivery metric]
+
+## Delivery Mapping *(mandatory)*
+
+- **Primary issue title**: [GitHub issue title derived from this spec]
+- **Planned branch label**: [e.g. `feat/spec-kit-workflow`]
+- **Expected PR scope**: [single slice, multi-file change, docs + script, etc.]
+- **Blocking dependencies**: [other issues, migrations, or `None`]

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -1,0 +1,74 @@
+---
+
+description: "Mtafiti task list template aligned to spec-first GitHub delivery"
+---
+
+# Tasks: [FEATURE NAME]
+
+**Input**: Design documents from `/specs/[###-feature-name]/`
+**Prerequisites**: `spec.md`, `plan.md`, `tasks.md`, plus supporting research artifacts when present
+
+## Format: `[ID] [P?] [Story] [Issue?] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking dependency)
+- **[Story]**: Maps to a user story such as `US1`
+- **[Issue?]**: Optional GitHub issue marker such as `GH-123`
+- Include exact file paths in descriptions
+- Keep each task small enough to map cleanly into issue, branch, and PR progress
+
+## Phase 1: Spec and Workflow Alignment
+
+- [ ] T001 Confirm `spec.md` reflects the latest clarified scope
+- [ ] T002 Confirm `plan.md` passes the constitution check
+- [ ] T003 Generate or refresh issue body with `python .github/scripts/spec_kit_workflow.py issue-body specs/[###-feature-name]`
+- [ ] T004 Mirror executable work into SQL todos and dependency tracking
+
+---
+
+## Phase 2: Foundational Work
+
+- [ ] T005 Establish shared prerequisites, migrations, contracts, or infra needed before user-story work starts
+- [ ] T006 [P] Add or update tests that guard the foundational behavior
+- [ ] T007 [P] Update documentation, knowledge graph, or skills inputs required by the foundation
+
+**Checkpoint**: Foundational work is complete and user-story slices can proceed independently
+
+---
+
+## Phase 3: User Story 1 - [Title] (Priority: P1)
+
+**Goal**: [What this story delivers]
+
+**Independent Test**: [How to validate the story in isolation]
+
+- [ ] T010 [P] [US1] Add or update tests in [exact path]
+- [ ] T011 [P] [US1] Implement model/service changes in [exact path]
+- [ ] T012 [US1] Wire endpoints, UI, or task behavior in [exact path]
+- [ ] T013 [US1] Validate and document the slice
+
+---
+
+## Phase 4: User Story 2 - [Title] (Priority: P2)
+
+**Goal**: [What this story delivers]
+
+**Independent Test**: [How to validate the story in isolation]
+
+- [ ] T020 [P] [US2] Add or update tests in [exact path]
+- [ ] T021 [P] [US2] Implement model/service changes in [exact path]
+- [ ] T022 [US2] Wire endpoints, UI, or task behavior in [exact path]
+- [ ] T023 [US2] Validate and document the slice
+
+---
+
+## Phase N: Integration and PR Readiness
+
+- [ ] T900 Re-run targeted validation and required merge-gate checks
+- [ ] T901 Generate or refresh PR body with `python .github/scripts/spec_kit_workflow.py pr-body specs/[###-feature-name]`
+- [ ] T902 Update issue checklist, risk notes, and done/blocker state
+- [ ] T903 Commit, push, open PR, and squash merge after review
+
+## Notes
+
+- `spec.md` and `plan.md` remain the canonical source for issue and PR generation.
+- If scope changes materially, update the spec bundle first and regenerate downstream artifacts.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,24 @@ chub search cookbook-crud101
 chub search theme
 ```
 
+### Spec-first delivery with Spec Kit
+
+This repository now keeps project-local `spec-kit` rules under `.specify/` and expects substantial work to flow through:
+
+1. `/speckit.specify`
+2. `/speckit.plan`
+3. `/speckit.tasks`
+4. `python .github/scripts/spec_kit_workflow.py issue-body specs/<feature>`
+5. `python .github/scripts/spec_kit_workflow.py pr-body specs/<feature>`
+
+Install the upstream CLI with:
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+```
+
+See `docs/spec-kit-workflow.md` for the repository-specific workflow, branch naming rules, and how knowledge graph / Context Hub inputs fit into the spec bundle.
+
 ### Faster local feedback loop
 
 ```bash

--- a/analysis/environment_inventory.yaml
+++ b/analysis/environment_inventory.yaml
@@ -2,7 +2,7 @@ EnvironmentInventory:
   programming_languages:
     -
       name: Python
-      file_count: 147
+      file_count: 150
     -
       name: YAML
       file_count: 28
@@ -11,7 +11,7 @@ EnvironmentInventory:
       file_count: 3
     -
       name: Markdown
-      file_count: 60
+      file_count: 65
   frameworks:
     -
       name: Django

--- a/docs/self-reflective-implementation.md
+++ b/docs/self-reflective-implementation.md
@@ -85,15 +85,17 @@ Template: use `.github/ISSUE_TEMPLATE/delivery-work-item.md` for consistent issu
 
 Use this repository workflow for new implementation slices:
 
-1. update or create the human-readable plan first,
-2. create/update the GitHub issue set for reviewable work items,
+1. create or refresh the `spec-kit` bundle first (`spec.md`, `plan.md`, `tasks.md`),
+2. generate or refresh the GitHub issue set from the spec bundle,
 3. mirror executable work into SQL todos with dependencies,
 4. implement one issue per branch,
 5. commit and push the branch,
-6. open a PR for review,
+6. open a PR generated from the same spec bundle for review,
 7. squash merge after review passes.
 
 Direct-to-`main` implementation is reserved for exceptional repository maintenance, not normal feature delivery.
+
+Use `docs/spec-kit-workflow.md` and `.github/scripts/spec_kit_workflow.py` to keep issue and PR text aligned with the approved spec bundle.
 
 ### Branch naming (required)
 

--- a/docs/spec-kit-workflow.md
+++ b/docs/spec-kit-workflow.md
@@ -1,0 +1,61 @@
+# Spec Kit workflow
+
+This repository now treats `spec-kit` artifacts as the primary planning and delivery source of truth for substantial work.
+
+## Install and initialize
+
+Install the CLI from the upstream repository:
+
+```bash
+uv tool install specify-cli --from git+https://github.com/github/spec-kit.git
+```
+
+In a fresh clone, initialize agent command support for your preferred assistant if needed:
+
+```bash
+specify init --here --ai copilot
+```
+
+The repository already contains project-local `.specify/` files that tailor the default `spec-kit` workflow to Mtafiti, so the generated commands should use the committed constitution and templates.
+
+## Source-of-truth workflow
+
+1. Ratify or update `.specify/constitution.md`.
+2. Create or refine the feature spec with `/speckit.specify`.
+3. Produce the implementation plan with `/speckit.plan`.
+4. Produce the task breakdown with `/speckit.tasks`.
+5. Generate GitHub issue and PR bodies from the feature bundle.
+6. Mirror executable work into SQL todos and then implement.
+
+For a feature directory such as `specs/012-spec-kit-workflow/`, use:
+
+```bash
+python .github/scripts/spec_kit_workflow.py validate specs/012-spec-kit-workflow
+python .github/scripts/spec_kit_workflow.py issue-body specs/012-spec-kit-workflow
+python .github/scripts/spec_kit_workflow.py pr-body specs/012-spec-kit-workflow --issue-number 123
+```
+
+Those outputs are designed to fit the repository's existing GitHub issue and PR contracts.
+
+## Required repository context
+
+Each spec and plan should capture:
+
+- affected services and code paths,
+- relevant design docs and prior checkpoints,
+- knowledge-graph nodes or generated skills that inform the slice,
+- Context Hub lookups for external APIs when repository evidence is insufficient,
+- planned validation commands and merge-gate checks.
+
+That keeps issue creation, implementation, and review anchored to the same artifact bundle.
+
+## Mapping to the existing delivery process
+
+- `spec.md`, `plan.md`, and `tasks.md` define the intended work.
+- `.github/scripts/spec_kit_workflow.py` turns that bundle into GitHub issue and PR bodies.
+- SQL todos remain the execution tracker for the active session.
+- Existing merge gates such as `.github/scripts/local_fast_feedback.sh --full-gate` remain mandatory before integration.
+
+## Branch naming
+
+`spec-kit` feature directories can keep a numeric identifier such as `012-spec-kit-workflow`, but Git branches in this repository must still use Git-safe Conventional Commit slugs such as `feat/spec-kit-workflow`.

--- a/knowledge_graph/edges.yaml
+++ b/knowledge_graph/edges.yaml
@@ -1062,6 +1062,10 @@ edges:
   -
     relationship: uses
     from: module:lims_tasks
+    to: framework:django
+  -
+    relationship: uses
+    from: module:lims_tasks
     to: module:core_celery
   -
     relationship: uses

--- a/knowledge_graph/nodes.yaml
+++ b/knowledge_graph/nodes.yaml
@@ -2330,7 +2330,7 @@ nodes:
       - notes
       - recorded_by
       - status
-    source: src/lims/models.py:920
+    source: src/lims/models.py:956
   -
     id: datamodel:site
     type: DataModel
@@ -2348,9 +2348,10 @@ nodes:
       - postcode
       - region
       - street
+      - studies
       - study
       - ward
-    source: src/lims/models.py:247
+    source: src/lims/models.py:268
   -
     id: datamodel:lab
     type: DataModel
@@ -2368,7 +2369,7 @@ nodes:
       - region
       - street
       - ward
-    source: src/lims/models.py:163
+    source: src/lims/models.py:174
   -
     id: datamodel:biospecimen
     type: DataModel
@@ -2393,7 +2394,7 @@ nodes:
       - status
       - study
       - subject_identifier
-    source: src/lims/models.py:583
+    source: src/lims/models.py:619
   -
     id: datamodel:biospecimenpool
     type: DataModel
@@ -2411,7 +2412,7 @@ nodes:
       - site
       - status
       - study
-    source: src/lims/models.py:678
+    source: src/lims/models.py:714
   -
     id: datamodel:biospecimentype
     type: DataModel
@@ -2426,7 +2427,7 @@ nodes:
       - name
       - next_sequence
       - sequence_padding
-    source: src/lims/models.py:554
+    source: src/lims/models.py:590
   -
     id: datamodel:batchplate
     type: DataModel
@@ -2440,7 +2441,7 @@ nodes:
       - metadata
       - plate_identifier
       - sequence_number
-    source: src/lims/models.py:1064
+    source: src/lims/models.py:1100
   -
     id: datamodel:processingbatch
     type: DataModel
@@ -2456,7 +2457,7 @@ nodes:
       - site
       - status
       - study
-    source: src/lims/models.py:1008
+    source: src/lims/models.py:1044
   -
     id: datamodel:accessioningmanifestitem
     type: DataModel
@@ -2476,7 +2477,7 @@ nodes:
       - quantity_unit
       - received_at
       - status
-    source: src/lims/models.py:824
+    source: src/lims/models.py:860
   -
     id: datamodel:receivingevent
     type: DataModel
@@ -2492,7 +2493,7 @@ nodes:
       - received_at
       - received_by
       - scan_value
-    source: src/lims/models.py:872
+    source: src/lims/models.py:908
   -
     id: datamodel:batchplateassignment
     type: DataModel
@@ -2504,7 +2505,7 @@ nodes:
       - plate
       - position_index
       - well_label
-    source: src/lims/models.py:1099
+    source: src/lims/models.py:1135
   -
     id: datamodel:metadataschemaversion
     type: DataModel
@@ -2515,7 +2516,7 @@ nodes:
       - schema
       - status
       - version_number
-    source: src/lims/models.py:456
+    source: src/lims/models.py:492
   -
     id: datamodel:tanzaniaaddresssyncrun
     type: DataModel
@@ -2535,7 +2536,7 @@ nodes:
       - status
       - throttle_seconds
       - triggered_by
-    source: src/lims/models.py:315
+    source: src/lims/models.py:351
   -
     id: datamodel:metadatafielddefinition
     type: DataModel
@@ -2552,7 +2553,7 @@ nodes:
       - name
       - placeholder
       - vocabulary
-    source: src/lims/models.py:391
+    source: src/lims/models.py:427
   -
     id: datamodel:metadataschema
     type: DataModel
@@ -2563,7 +2564,7 @@ nodes:
       - description
       - is_active
       - name
-    source: src/lims/models.py:440
+    source: src/lims/models.py:476
   -
     id: datamodel:metadatavocabulary
     type: DataModel
@@ -2574,7 +2575,7 @@ nodes:
       - description
       - is_active
       - name
-    source: src/lims/models.py:351
+    source: src/lims/models.py:387
   -
     id: datamodel:study
     type: DataModel
@@ -2587,7 +2588,7 @@ nodes:
       - name
       - sponsor
       - status
-    source: src/lims/models.py:217
+    source: src/lims/models.py:238
   -
     id: datamodel:country
     type: DataModel
@@ -2600,7 +2601,7 @@ nodes:
       - name
       - slug
       - source_url
-    source: src/lims/models.py:19
+    source: src/lims/models.py:30
   -
     id: datamodel:postcode
     type: DataModel
@@ -2613,7 +2614,7 @@ nodes:
       - source_path
       - source_url
       - street
-    source: src/lims/models.py:138
+    source: src/lims/models.py:149
   -
     id: datamodel:platelayouttemplate
     type: DataModel
@@ -2626,7 +2627,7 @@ nodes:
       - key
       - name
       - rows
-    source: src/lims/models.py:980
+    source: src/lims/models.py:1016
   -
     id: datamodel:metadataschemafield
     type: DataModel
@@ -2640,7 +2641,7 @@ nodes:
       - required
       - schema_version
       - validation_rules
-    source: src/lims/models.py:484
+    source: src/lims/models.py:520
   -
     id: datamodel:biospecimenpoolmember
     type: DataModel
@@ -2651,7 +2652,7 @@ nodes:
       - contributed_unit
       - pool
       - specimen
-    source: src/lims/models.py:734
+    source: src/lims/models.py:770
   -
     id: datamodel:region
     type: DataModel
@@ -2665,7 +2666,7 @@ nodes:
       - slug
       - source_path
       - source_url
-    source: src/lims/models.py:34
+    source: src/lims/models.py:45
   -
     id: datamodel:timestampeduuidmodel
     type: DataModel
@@ -2694,7 +2695,7 @@ nodes:
       - source_system
       - status
       - study
-    source: src/lims/models.py:766
+    source: src/lims/models.py:802
   -
     id: datamodel:ward
     type: DataModel
@@ -2708,7 +2709,7 @@ nodes:
       - slug
       - source_path
       - source_url
-    source: src/lims/models.py:86
+    source: src/lims/models.py:97
   -
     id: datamodel:metadatavocabularyitem
     type: DataModel
@@ -2720,7 +2721,7 @@ nodes:
       - sort_order
       - value
       - vocabulary
-    source: src/lims/models.py:367
+    source: src/lims/models.py:403
   -
     id: datamodel:district
     type: DataModel
@@ -2734,7 +2735,7 @@ nodes:
       - slug
       - source_path
       - source_url
-    source: src/lims/models.py:60
+    source: src/lims/models.py:71
   -
     id: datamodel:street
     type: DataModel
@@ -2748,7 +2749,7 @@ nodes:
       - source_path
       - source_url
       - ward
-    source: src/lims/models.py:112
+    source: src/lims/models.py:123
   -
     id: datamodel:metadataschemabinding
     type: DataModel
@@ -2760,7 +2761,7 @@ nodes:
       - target_key
       - target_label
       - target_type
-    source: src/lims/models.py:523
+    source: src/lims/models.py:559
   -
     id: datamodel:tenantserviceroute
     type: DataModel

--- a/src/tests/test_spec_kit_workflow.py
+++ b/src/tests/test_spec_kit_workflow.py
@@ -1,0 +1,96 @@
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / ".github" / "scripts" / "spec_kit_workflow.py"
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec is not None and spec.loader is not None
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_bundle(root: Path) -> Path:
+    feature_dir = root / "specs" / "012-spec-kit-workflow"
+    feature_dir.mkdir(parents=True)
+    (feature_dir / "spec.md").write_text(
+        "# Feature Specification: Spec Kit workflow\n\n"
+        "## Repository Context\n\n"
+        "- `docs/spec-kit-workflow.md`\n"
+        "- `knowledge_graph/nodes.yaml`\n\n"
+        "## Success Criteria\n\n"
+        "- Spec artifacts generate GitHub delivery bodies consistently.\n\n"
+        "## Delivery Mapping\n\n"
+        "- Primary issue title: Integrate spec-kit workflow\n"
+        "- Planned branch label: `feat/spec-kit-workflow`\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "plan.md").write_text(
+        "# Implementation Plan: Spec Kit workflow\n\n"
+        "## Summary\n\n"
+        "Make spec-kit artifacts the source of truth for issues and PRs.\n\n"
+        "## Planned Validation\n\n"
+        "- python .github/scripts/spec_kit_workflow.py validate specs/012-spec-kit-workflow\n"
+        "- .github/scripts/local_fast_feedback.sh --full-gate\n",
+        encoding="utf-8",
+    )
+    (feature_dir / "tasks.md").write_text(
+        "# Tasks: Spec Kit workflow\n\n"
+        "- [x] T001 Confirm `spec.md` reflects the latest clarified scope\n"
+        "- [ ] T002 Generate issue body from the feature bundle\n"
+        "- [ ] T003 Generate PR body from the feature bundle\n",
+        encoding="utf-8",
+    )
+    return feature_dir
+
+
+def test_build_issue_body_includes_spec_artifacts(tmp_path):
+    module = _load_module(SCRIPT_PATH, "spec_kit_workflow")
+    feature_dir = _write_bundle(tmp_path)
+    module.REPO_ROOT = tmp_path
+
+    body = module.build_issue_body(str(feature_dir))
+
+    assert "## Spec Kit artifacts" in body
+    assert "`specs/012-spec-kit-workflow/spec.md`" in body
+    assert "Task progress at issue creation: 1/3 complete" in body
+    assert "Make spec-kit artifacts the source of truth for issues and PRs." in body
+
+
+def test_build_pr_body_uses_validation_section(tmp_path):
+    module = _load_module(SCRIPT_PATH, "spec_kit_workflow_pr")
+    feature_dir = _write_bundle(tmp_path)
+    module.REPO_ROOT = tmp_path
+
+    body = module.build_pr_body(str(feature_dir), issue_number="123")
+
+    assert "Linked issue: #123" in body
+    assert "python .github/scripts/spec_kit_workflow.py validate specs/012-spec-kit-workflow" in body
+    assert "Task progress: 1/3 complete" in body
+
+
+def test_summary_command_emits_json(tmp_path):
+    feature_dir = _write_bundle(tmp_path)
+    env = dict(os.environ, SPEC_KIT_WORKFLOW_ROOT=str(tmp_path))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "summary", str(feature_dir)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["feature_dir"] == "specs/012-spec-kit-workflow"
+    assert payload["task_counts"] == {"total": 3, "done": 1}


### PR DESCRIPTION
## Summary

- add repo-local `spec-kit` constitution and templates for Mtafiti
- add `spec_kit_workflow.py` to generate issue and PR bodies from spec bundles
- update workflow docs/templates and refresh generated knowledge-graph artifacts

## Validation

- focused workflow tests passed
- `.github/scripts/local_fast_feedback.sh --full-gate` passed