### PR TITLE
feat: add lims storage admin ui

### DIFF
--- a/docs/lab-lims.md
+++ b/docs/lab-lims.md
@@ -28,6 +28,7 @@ This document defines the target tenant-aware LIMS service exposed at:
   - `/lims/biospecimens/`
   - `/lims/receiving/`
   - `/lims/processing/`
+  - `/lims/storage/`
 - Service-aware routing via `TenantServiceRoute` records for `service_key="lims"`
 - Permission model helpers in `src/lims/permissions.py` define module roles, legacy-role compatibility, and guardian-compatible object permission names.
 - Reference-domain models and APIs now live directly in `src/lims/models.py` and `src/lims/views.py`.
@@ -263,7 +264,7 @@ The single-sample path has now moved one step closer to the intended cookbook-st
 
 Those dynamic steps are driven by the published sample-type metadata binding. Schema fields now expose a formbuilder-compatible field description in the metadata API, and the operator wizard uses a repository-native renderer so the controls stay aligned with the shared portal shell instead of introducing a separate frontend stack.
 
-The same launchpad-versus-task-page pattern now extends to reference and metadata setup:
+The same launchpad-versus-task-page pattern now extends to reference, metadata, and storage/inventory setup:
 
 - `/lims/reference/` stays an overview/launchpad for labs, studies, sites, and geography sync status
 - `/lims/reference/labs/create/`
@@ -276,6 +277,12 @@ The same launchpad-versus-task-page pattern now extends to reference and metadat
 - `/lims/metadata/schemas/create/`
 - `/lims/metadata/bindings/create/`
 - `/lims/metadata/versions/publish/`
+- `/lims/storage/` stays an overview/launchpad for storage hierarchy, placements, materials, lots, and ledger activity
+- `/lims/storage/locations/create/`
+- `/lims/storage/placements/create/`
+- `/lims/storage/materials/create/`
+- `/lims/storage/lots/create/`
+- `/lims/storage/transactions/create/`
 
 This keeps operator/admin pages closer to the CRUD cookbook direction: summary pages remain navigational, while each input page exposes one focused task with one primary submit action.
 
@@ -313,7 +320,7 @@ The companion page at `/lims/processing/` provides a first admin-style batch wor
 
 ## Storage and non-sample inventory direction
 
-The next storage/inventory slice should treat two related concerns explicitly:
+The current storage/inventory slice now treats two related concerns explicitly:
 
 - sample storage and movement history for biospecimens, aliquots, pools, and derived artifacts
 - non-sample inventory for lab materials and consumables such as reagents, tubes, kits, media, and labels
@@ -326,6 +333,8 @@ For non-sample inventory, the target model should remain relational and tenant-s
 - storage location and placement
 - receipt, adjustment, reservation, transfer, usage, expiry, and disposal transactions
 - workflow/task linkage when a consumable is used during execution
+
+The admin-style HTML surface now mirrors those concerns through `/lims/storage/` plus dedicated task pages for location creation, specimen placement, material setup, lot receipt, and stock-ledger transactions. Like receiving/reference/metadata, the launchpad stays navigational while each child page keeps one primary submit action tied to the existing JSON APIs.
 
 ## Geography import and Tanzania sync
 

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -159,6 +159,12 @@ from lims.views import (
     lims_reference_create_site_page,
     lims_reference_create_study_page,
     lims_reference_page,
+    lims_storage_create_location_page,
+    lims_storage_create_lot_page,
+    lims_storage_create_material_page,
+    lims_storage_create_placement_page,
+    lims_storage_create_transaction_page,
+    lims_storage_inventory_page,
 )
 from tenants.views import tenant_services, tenants
 
@@ -189,6 +195,12 @@ urlpatterns = [
     path('lims/receiving/batch/', lims_receiving_batch_page, name='lims_receiving_batch_page'),
     path('lims/receiving/edc-import/', lims_receiving_edc_import_page, name='lims_receiving_edc_import_page'),
     path('lims/processing/', lims_processing_page, name='lims_processing_page'),
+    path('lims/storage/', lims_storage_inventory_page, name='lims_storage_inventory_page'),
+    path('lims/storage/locations/create/', lims_storage_create_location_page, name='lims_storage_create_location_page'),
+    path('lims/storage/placements/create/', lims_storage_create_placement_page, name='lims_storage_create_placement_page'),
+    path('lims/storage/materials/create/', lims_storage_create_material_page, name='lims_storage_create_material_page'),
+    path('lims/storage/lots/create/', lims_storage_create_lot_page, name='lims_storage_create_lot_page'),
+    path('lims/storage/transactions/create/', lims_storage_create_transaction_page, name='lims_storage_create_transaction_page'),
     path('api/v1/governance/policies', governance_policies, name='governance_policies'),
     path(
         'api/v1/governance/policies/<uuid:policy_id>',

--- a/src/lims/templates/lims/dashboard.html
+++ b/src/lims/templates/lims/dashboard.html
@@ -9,6 +9,7 @@
   {% include "core/ui/includes/count_stat_card.html" with card_title="Biospecimens" count_label="registered" count_value=payload.cards.biospecimens link_href="/lims/biospecimens/" link_label="Open biospecimens" %}
   {% include "core/ui/includes/count_stat_card.html" with card_title="Manifests" count_label="intake runs" count_value=payload.cards.manifests link_href="/lims/receiving/" link_label="Open receiving" %}
   {% include "core/ui/includes/count_stat_card.html" with card_title="Batches" count_label="processing sets" count_value=payload.cards.batches link_href="/lims/processing/" link_label="Open processing" %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Storage nodes" count_label="tracked locations" count_value=payload.cards.storage_locations link_href="/lims/storage/" link_label="Open storage" %}
 </div>
 
 <section class="panel">

--- a/src/lims/templates/lims/storage_create_location.html
+++ b/src/lims/templates/lims/storage_create_location.html
@@ -1,0 +1,54 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Storage" parent_url="/lims/storage/" current_label="Create location" %}
+
+{% if payload.capabilities.can_manage_storage %}
+<section class="panel" data-lims-action="storage-location-create">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Create storage location" panel_description="Register one facility, area, equipment, container, or position node at a time." %}
+  <div class="section-stack">
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Lab</span><select class="select" data-lims-field="storage-location-lab">{% for option in payload.lab_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Parent location</span><select class="select" data-lims-field="storage-location-parent"><option value="">None (top-level facility)</option>{% for option in payload.parent_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Level</span><select class="select" data-lims-field="storage-location-level">{% for option in payload.level_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Temperature zone</span><select class="select" data-lims-field="storage-location-temperature">{% for option in payload.temperature_zone_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+    </div>
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Location name</span><input class="input" data-lims-field="storage-location-name" placeholder="Freezer A / Rack 1 / Box 4..." /></label>
+      <label class="field-group"><span class="field-label">Location code</span><input class="input" data-lims-field="storage-location-code" placeholder="Auto-generated when blank" /></label>
+      <label class="field-group"><span class="field-label">Capacity</span><input class="input" type="number" min="1" data-lims-field="storage-location-capacity" placeholder="Optional" /></label>
+      <label class="field-group"><span class="field-label">Active</span><select class="select" data-lims-field="storage-location-active"><option value="true">Yes</option><option value="false">No</option></select></label>
+    </div>
+    <label class="field-group"><span class="field-label">Metadata JSON</span><textarea class="textarea" rows="5" data-lims-field="storage-location-metadata">{}</textarea></label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="createStorageLocation()"><span class="material-symbols-outlined button-icon" aria-hidden="true">add_home_work</span><span>Create storage location</span></button>
+      <a class="button button-secondary" href="/lims/storage/">Back to storage</a>
+    </div>
+  </div>
+</section>
+{% endif %}
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+async function createStorageLocation() {
+  let metadata;
+  try {
+    metadata = limsJsonValue("storage-location-metadata", {});
+  } catch (error) {
+    limsFeedback(error.message, true);
+    return;
+  }
+  await limsPortalAction("/api/v1/lims/storage-locations", {
+    lab_id: limsValue("storage-location-lab"),
+    parent_id: limsOptionalValue("storage-location-parent"),
+    name: limsValue("storage-location-name"),
+    code: limsOptionalValue("storage-location-code"),
+    level: limsValue("storage-location-level"),
+    temperature_zone: limsOptionalValue("storage-location-temperature"),
+    capacity: limsOptionalValue("storage-location-capacity"),
+    is_active: limsValue("storage-location-active") === "true",
+    metadata: metadata,
+  }, "Storage location created");
+}
+{% endblock %}

--- a/src/lims/templates/lims/storage_create_lot.html
+++ b/src/lims/templates/lims/storage_create_lot.html
@@ -1,0 +1,78 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Storage" parent_url="/lims/storage/" current_label="Receive lot" %}
+
+{% if payload.capabilities.can_manage_inventory %}
+<section class="panel" data-lims-action="inventory-lot-create">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Receive inventory lot" panel_description="Capture a lot receipt together with quantity, storage assignment, and expiry metadata." %}
+  <div class="section-stack">
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Material</span><select class="select" data-lims-field="inventory-lot-material">{% for option in payload.material_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Lab</span><select class="select" data-lims-field="inventory-lot-lab">{% for option in payload.lab_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Storage location</span><select class="select" data-lims-field="inventory-lot-location"><option value="">None</option>{% for option in payload.storage_location_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+    </div>
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Lot number</span><input class="input" data-lims-field="inventory-lot-number" /></label>
+      <label class="field-group"><span class="field-label">Vendor</span><input class="input" data-lims-field="inventory-lot-vendor" /></label>
+      <label class="field-group"><span class="field-label">Received on</span><input class="input" type="date" data-lims-field="inventory-lot-received-on" /></label>
+      <label class="field-group"><span class="field-label">Expires on</span><input class="input" type="date" data-lims-field="inventory-lot-expires-on" /></label>
+    </div>
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Initial quantity</span><input class="input" data-lims-field="inventory-lot-initial-quantity" value="0" /></label>
+      <label class="field-group"><span class="field-label">Unit of measure</span><input class="input" data-lims-field="inventory-lot-unit" placeholder="box / tube / mL" /></label>
+      <label class="field-group"><span class="field-label">Active</span><select class="select" data-lims-field="inventory-lot-active"><option value="true">Yes</option><option value="false">No</option></select></label>
+    </div>
+    <label class="field-group"><span class="field-label">Notes</span><textarea class="textarea" rows="3" data-lims-field="inventory-lot-notes"></textarea></label>
+    <label class="field-group"><span class="field-label">Metadata JSON</span><textarea class="textarea" rows="4" data-lims-field="inventory-lot-metadata">{}</textarea></label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="createInventoryLot()"><span class="material-symbols-outlined button-icon" aria-hidden="true">local_shipping</span><span>Receive inventory lot</span></button>
+      <a class="button button-secondary" href="/lims/storage/">Back to storage</a>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Recent lot receipts" panel_description="Newest lots recorded for this tenant." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Lot</th><th>Material</th><th>On hand</th><th>Received</th></tr></thead>
+      <tbody>
+        {% for item in payload.recent_lots %}
+        <tr><td>{{ item.lot_number }}</td><td>{{ item.material_id }}</td><td>{{ item.on_hand_quantity }} {{ item.unit_of_measure }}</td><td>{{ item.received_on|default:"-" }}</td></tr>
+        {% empty %}
+        <tr><td colspan="4">No lots yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+async function createInventoryLot() {
+  let metadata;
+  try {
+    metadata = limsJsonValue("inventory-lot-metadata", {});
+  } catch (error) {
+    limsFeedback(error.message, true);
+    return;
+  }
+  await limsPortalAction("/api/v1/lims/inventory-lots", {
+    material_id: limsValue("inventory-lot-material"),
+    lab_id: limsValue("inventory-lot-lab"),
+    storage_location_id: limsOptionalValue("inventory-lot-location"),
+    lot_number: limsValue("inventory-lot-number"),
+    vendor: limsValue("inventory-lot-vendor"),
+    received_on: limsOptionalValue("inventory-lot-received-on"),
+    expires_on: limsOptionalValue("inventory-lot-expires-on"),
+    notes: limsValue("inventory-lot-notes"),
+    initial_quantity: limsValue("inventory-lot-initial-quantity"),
+    unit_of_measure: limsValue("inventory-lot-unit"),
+    metadata: metadata,
+    is_active: limsValue("inventory-lot-active") === "true",
+  }, "Inventory lot created");
+}
+{% endblock %}

--- a/src/lims/templates/lims/storage_create_material.html
+++ b/src/lims/templates/lims/storage_create_material.html
@@ -1,0 +1,55 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Storage" parent_url="/lims/storage/" current_label="Create material" %}
+
+{% if payload.capabilities.can_manage_inventory %}
+<section class="panel" data-lims-action="inventory-material-create">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Create inventory material" panel_description="Register one catalog entry for reagents, kits, consumables, labels, media, or other stock items." %}
+  <div class="section-stack">
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Material name</span><input class="input" data-lims-field="inventory-material-name" /></label>
+      <label class="field-group"><span class="field-label">Material code</span><input class="input" data-lims-field="inventory-material-code" placeholder="Auto-generated when blank" /></label>
+      <label class="field-group"><span class="field-label">Category</span><select class="select" data-lims-field="inventory-material-category">{% for option in payload.category_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Default unit</span><input class="input" data-lims-field="inventory-material-unit" placeholder="tube / box / mL / test" /></label>
+    </div>
+    <label class="field-group"><span class="field-label">Description</span><textarea class="textarea" rows="4" data-lims-field="inventory-material-description"></textarea></label>
+    <label class="field-group"><span class="field-label">Active</span><select class="select" data-lims-field="inventory-material-active"><option value="true">Yes</option><option value="false">No</option></select></label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="createInventoryMaterial()"><span class="material-symbols-outlined button-icon" aria-hidden="true">inventory_2</span><span>Create inventory material</span></button>
+      <a class="button button-secondary" href="/lims/storage/">Back to storage</a>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Recent catalog entries" panel_description="Newest material definitions available for lot receipt." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Name</th><th>Code</th><th>Category</th><th>Unit</th></tr></thead>
+      <tbody>
+        {% for item in payload.recent_materials %}
+        <tr><td>{{ item.name }}</td><td>{{ item.code }}</td><td>{{ item.category }}</td><td>{{ item.default_unit|default:"-" }}</td></tr>
+        {% empty %}
+        <tr><td colspan="4">No materials yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+async function createInventoryMaterial() {
+  await limsPortalAction("/api/v1/lims/inventory-materials", {
+    name: limsValue("inventory-material-name"),
+    code: limsOptionalValue("inventory-material-code"),
+    category: limsValue("inventory-material-category"),
+    description: limsValue("inventory-material-description"),
+    default_unit: limsValue("inventory-material-unit"),
+    is_active: limsValue("inventory-material-active") === "true",
+  }, "Inventory material created");
+}
+{% endblock %}

--- a/src/lims/templates/lims/storage_create_placement.html
+++ b/src/lims/templates/lims/storage_create_placement.html
@@ -1,0 +1,77 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Storage" parent_url="/lims/storage/" current_label="Record placement" %}
+
+{% if payload.capabilities.can_manage_storage %}
+<section class="panel" data-lims-action="storage-placement-create">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Record specimen placement" panel_description="Append an immutable storage history entry for either a biospecimen or a biospecimen pool." %}
+  <div class="section-stack">
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Biospecimen</span><select class="select" data-lims-field="storage-placement-specimen"><option value="">None</option>{% for option in payload.specimen_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Biospecimen pool</span><select class="select" data-lims-field="storage-placement-pool"><option value="">None</option>{% for option in payload.pool_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Destination location</span><select class="select" data-lims-field="storage-placement-location">{% for option in payload.location_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Reason</span><select class="select" data-lims-field="storage-placement-reason">{% for option in payload.reason_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+    </div>
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Quantity snapshot</span><input class="input" data-lims-field="storage-placement-quantity" value="0" /></label>
+      <label class="field-group"><span class="field-label">Quantity unit</span><input class="input" data-lims-field="storage-placement-unit" placeholder="mL / punches / tubes" /></label>
+      <label class="field-group"><span class="field-label">Placed by</span><input class="input" data-lims-field="storage-placement-by" placeholder="Operator name or badge" /></label>
+    </div>
+    <label class="field-group"><span class="field-label">Notes</span><textarea class="textarea" rows="4" data-lims-field="storage-placement-notes"></textarea></label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="recordStoragePlacement()"><span class="material-symbols-outlined button-icon" aria-hidden="true">move_item</span><span>Record placement</span></button>
+      <a class="button button-secondary" href="/lims/storage/">Back to storage</a>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Recent placement history" panel_description="Immutable storage history is shown here for quick admin review." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Artifact</th><th>Reason</th><th>Location</th><th>Quantity</th></tr></thead>
+      <tbody>
+        {% for item in payload.recent_records %}
+        <tr>
+          <td>{{ item.biospecimen_id|default:item.biospecimen_pool_id }}</td>
+          <td>{{ item.reason }}</td>
+          <td>{% for node in item.location.path %}{% if not forloop.first %} / {% endif %}{{ node.code }}{% endfor %}</td>
+          <td>{{ item.quantity_snapshot }} {{ item.quantity_unit }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="4">No placement records yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+async function recordStoragePlacement() {
+  const specimenId = limsOptionalValue("storage-placement-specimen");
+  const poolId = limsOptionalValue("storage-placement-pool");
+  if (!specimenId && !poolId) {
+    limsFeedback("Select a biospecimen or pool", true);
+    return;
+  }
+  if (specimenId && poolId) {
+    limsFeedback("Choose either biospecimen or pool, not both", true);
+    return;
+  }
+  const endpoint = specimenId
+    ? "/api/v1/lims/biospecimens/" + specimenId + "/storage-records"
+    : "/api/v1/lims/biospecimen-pools/" + poolId + "/storage-records";
+  await limsPortalAction(endpoint, {
+    location_id: limsValue("storage-placement-location"),
+    reason: limsValue("storage-placement-reason"),
+    quantity_snapshot: limsValue("storage-placement-quantity"),
+    quantity_unit: limsValue("storage-placement-unit"),
+    placed_by: limsValue("storage-placement-by"),
+    notes: limsValue("storage-placement-notes"),
+  }, "Placement recorded");
+}
+{% endblock %}

--- a/src/lims/templates/lims/storage_create_transaction.html
+++ b/src/lims/templates/lims/storage_create_transaction.html
@@ -1,0 +1,65 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Storage" parent_url="/lims/storage/" current_label="Record transaction" %}
+
+{% if payload.capabilities.can_manage_inventory %}
+<section class="panel" data-lims-action="inventory-transaction-create">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Record stock transaction" panel_description="Apply a transaction directly to an inventory lot so the ledger stays explicit and auditable." %}
+  <div class="section-stack">
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Inventory lot</span><select class="select" data-lims-field="inventory-transaction-lot">{% for option in payload.lot_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Transaction type</span><select class="select" data-lims-field="inventory-transaction-type">{% for option in payload.transaction_type_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Quantity delta</span><input class="input" data-lims-field="inventory-transaction-delta" value="0" /></label>
+      <label class="field-group"><span class="field-label">Location</span><select class="select" data-lims-field="inventory-transaction-location"><option value="">None</option>{% for option in payload.location_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+    </div>
+    <div class="field-grid field-grid--wide">
+      <label class="field-group"><span class="field-label">Linked biospecimen</span><select class="select" data-lims-field="inventory-transaction-specimen"><option value="">None</option>{% for option in payload.specimen_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+      <label class="field-group"><span class="field-label">Linked pool</span><select class="select" data-lims-field="inventory-transaction-pool"><option value="">None</option>{% for option in payload.pool_options %}<option value="{{ option.value }}">{{ option.label }}</option>{% endfor %}</select></label>
+    </div>
+    <label class="field-group"><span class="field-label">Notes</span><textarea class="textarea" rows="4" data-lims-field="inventory-transaction-notes"></textarea></label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="createInventoryTransaction()"><span class="material-symbols-outlined button-icon" aria-hidden="true">sync_alt</span><span>Record stock transaction</span></button>
+      <a class="button button-secondary" href="/lims/storage/">Back to storage</a>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Recent stock-ledger entries" panel_description="Latest inventory movements posted against lots." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Lot</th><th>Type</th><th>Delta</th><th>Resulting quantity</th></tr></thead>
+      <tbody>
+        {% for item in payload.recent_transactions %}
+        <tr><td>{{ item.lot_id }}</td><td>{{ item.transaction_type }}</td><td>{{ item.quantity_delta }}</td><td>{{ item.resulting_quantity }}</td></tr>
+        {% empty %}
+        <tr><td colspan="4">No transactions yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+async function createInventoryTransaction() {
+  const specimenId = limsOptionalValue("inventory-transaction-specimen");
+  const poolId = limsOptionalValue("inventory-transaction-pool");
+  if (specimenId && poolId) {
+    limsFeedback("Choose either linked biospecimen or linked pool, not both", true);
+    return;
+  }
+  const lotId = limsValue("inventory-transaction-lot");
+  await limsPortalAction("/api/v1/lims/inventory-lots/" + lotId + "/transactions", {
+    transaction_type: limsValue("inventory-transaction-type"),
+    quantity_delta: limsValue("inventory-transaction-delta"),
+    location_id: limsOptionalValue("inventory-transaction-location"),
+    biospecimen_id: specimenId,
+    biospecimen_pool_id: poolId,
+    notes: limsValue("inventory-transaction-notes"),
+  }, "Inventory transaction recorded");
+}
+{% endblock %}

--- a/src/lims/templates/lims/storage_inventory.html
+++ b/src/lims/templates/lims/storage_inventory.html
@@ -1,0 +1,124 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="LIMS" parent_url="/lims/" current_label="Storage" %}
+
+<div class="stat-grid">
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Locations" count_label="storage nodes" count_value=payload.cards.locations %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Placements" count_label="history rows" count_value=payload.cards.storage_records %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Materials" count_label="catalog entries" count_value=payload.cards.materials %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Active lots" count_label="inventory batches" count_value=payload.cards.active_lots %}
+</div>
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Choose a storage or inventory workflow" panel_description="Administration stays split into focused pages so hierarchy, placement, catalog, lot, and ledger actions are not mixed together." %}
+  <div class="cards">
+    {% for item in payload.actions %}
+    {% if item.enabled %}
+    <article class="card">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">{{ item.title }}</h2>
+          <p class="panel-description">{{ item.description }}</p>
+        </div>
+        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
+      </div>
+      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
+    </article>
+    {% endif %}
+    {% empty %}
+    <article class="card"><p>No storage or inventory admin actions are available for your current role.</p></article>
+    {% endfor %}
+  </div>
+</section>
+
+<div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+  <section class="panel">
+    {% include "core/ui/includes/panel_header.html" with panel_title="Storage hierarchy" panel_description="Recent storage nodes with their resolved breadcrumb path." %}
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Location</th><th>Lab</th><th>Level</th><th>Path</th></tr></thead>
+        <tbody>
+          {% for item in payload.locations %}
+          <tr>
+            <td>{{ item.name }}</td>
+            <td>{{ item.lab_id }}</td>
+            <td>{{ item.level }}</td>
+            <td>{% for node in item.path %}{% if not forloop.first %} / {% endif %}{{ node.code }}{% endfor %}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="4">No storage locations yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="panel">
+    {% include "core/ui/includes/panel_header.html" with panel_title="Recent placements" panel_description="Latest specimen or pool placement events appended to the storage history." %}
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Artifact</th><th>Reason</th><th>Location</th><th>Quantity</th></tr></thead>
+        <tbody>
+          {% for item in payload.storage_records %}
+          <tr>
+            <td>{{ item.biospecimen_id|default:item.biospecimen_pool_id }}</td>
+            <td>{{ item.reason }}</td>
+            <td>{% for node in item.location.path %}{% if not forloop.first %} / {% endif %}{{ node.code }}{% endfor %}</td>
+            <td>{{ item.quantity_snapshot }} {{ item.quantity_unit }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="4">No placement history yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+
+<div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+  <section class="panel">
+    {% include "core/ui/includes/panel_header.html" with panel_title="Inventory catalog" panel_description="Current materials available for lot receipt." %}
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Material</th><th>Code</th><th>Category</th><th>Unit</th></tr></thead>
+        <tbody>
+          {% for item in payload.materials %}
+          <tr><td>{{ item.name }}</td><td>{{ item.code }}</td><td>{{ item.category }}</td><td>{{ item.default_unit|default:"-" }}</td></tr>
+          {% empty %}
+          <tr><td colspan="4">No materials yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="panel">
+    {% include "core/ui/includes/panel_header.html" with panel_title="Recent lots and transactions" panel_description="Newest lot receipts alongside the latest stock-ledger movements." %}
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Lot</th><th>Material</th><th>On hand</th><th>Storage</th></tr></thead>
+        <tbody>
+          {% for item in payload.lots %}
+          <tr><td>{{ item.lot_number }}</td><td>{{ item.material_id }}</td><td>{{ item.on_hand_quantity }} {{ item.unit_of_measure }}</td><td>{{ item.storage_location_id|default:"-" }}</td></tr>
+          {% empty %}
+          <tr><td colspan="4">No lots yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div class="table-wrap" style="margin-top: 1rem;">
+      <table>
+        <thead><tr><th>Lot</th><th>Type</th><th>Delta</th><th>Resulting</th></tr></thead>
+        <tbody>
+          {% for item in payload.recent_transactions %}
+          <tr><td>{{ item.lot_id }}</td><td>{{ item.transaction_type }}</td><td>{{ item.quantity_delta }}</td><td>{{ item.resulting_quantity }}</td></tr>
+          {% empty %}
+          <tr><td colspan="4">No inventory transactions yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/src/lims/views.py
+++ b/src/lims/views.py
@@ -144,6 +144,7 @@ def _lims_navigation(request, active_key: str) -> dict[str, object]:
         ("lims-biospecimens", "Biospecimens", "biotech", "/lims/biospecimens/", "lims.artifact.view"),
         ("lims-receiving", "Receiving", "inventory_2", "/lims/receiving/", "lims.artifact.view"),
         ("lims-processing", "Processing", "science", "/lims/processing/", "lims.artifact.view"),
+        ("lims-storage", "Storage", "inventory", "/lims/storage/", "lims.storage.view"),
     ]
     for key, label, icon, href, permission_key in candidates:
         if _has_permission(request, permission_key):
@@ -176,6 +177,10 @@ def _page_payload_base(request, *, active_key: str, title: str, summary: str, ki
             "can_manage_metadata": _has_permission(request, "lims.metadata.manage"),
             "can_view_artifacts": _has_permission(request, "lims.artifact.view"),
             "can_manage_artifacts": _has_permission(request, "lims.artifact.manage"),
+            "can_view_storage": _has_permission(request, "lims.storage.view"),
+            "can_manage_storage": _has_permission(request, "lims.storage.manage"),
+            "can_view_inventory": _has_permission(request, "lims.inventory.view"),
+            "can_manage_inventory": _has_permission(request, "lims.inventory.manage"),
             "can_execute_tasks": _has_permission(request, "lims.workflow.execute"),
             "can_approve_tasks": _has_permission(request, "lims.workflow.approve"),
         },
@@ -212,12 +217,14 @@ def _dashboard_payload(request) -> dict[str, object]:
     specimen_count = Biospecimen.objects.count()
     manifest_count = AccessioningManifest.objects.count()
     batch_count = ProcessingBatch.objects.count()
+    storage_location_count = StorageLocation.objects.count()
     payload["cards"] = {
         "labs": labs_count,
         "schemas": schema_count,
         "biospecimens": specimen_count,
         "manifests": manifest_count,
         "batches": batch_count,
+        "storage_locations": storage_location_count,
     }
     payload["launchpad"] = [
         {
@@ -249,6 +256,16 @@ def _dashboard_payload(request) -> dict[str, object]:
             "description": "Create plate-based batches, review assignments, and trigger worksheet print jobs.",
             "href": "/lims/processing/",
             "status": "ready" if payload["capabilities"]["can_view_artifacts"] else "restricted",
+        },
+        {
+            "title": "Storage and inventory",
+            "description": "Administer storage hierarchies, specimen placement, consumable materials, and stock-ledger activity.",
+            "href": "/lims/storage/",
+            "status": (
+                "ready"
+                if (payload["capabilities"]["can_view_storage"] or payload["capabilities"]["can_view_inventory"])
+                else "restricted"
+            ),
         },
     ]
     payload["recent_manifests"] = [
@@ -733,6 +750,259 @@ def _processing_page_payload(request) -> dict[str, object]:
     payload["batch_options"] = [
         {"value": str(item.id), "label": f"{item.batch_identifier} ({item.status})"}
         for item in ProcessingBatch.objects.order_by("-created_at")[:50]
+    ]
+    return payload
+
+
+def _storage_inventory_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-storage",
+        title="Storage and inventory administration",
+        summary="Choose a focused storage or inventory administration task, then complete it from a dedicated page.",
+        kicker="Storage operations",
+    )
+    payload["cards"] = {
+        "locations": StorageLocation.objects.count(),
+        "storage_records": BiospecimenStorageRecord.objects.count(),
+        "materials": InventoryMaterial.objects.count(),
+        "active_lots": InventoryLot.objects.filter(is_active=True).count(),
+    }
+    payload["locations"] = [
+        _storage_location_to_dict(item)
+        for item in StorageLocation.objects.select_related(
+            "lab",
+            "parent",
+            "parent__parent",
+            "parent__parent__parent",
+            "parent__parent__parent__parent",
+        ).order_by("lab__name", "level", "name")[:10]
+    ]
+    payload["storage_records"] = [
+        _biospecimen_storage_record_to_dict(item)
+        for item in BiospecimenStorageRecord.objects.select_related(
+            "biospecimen",
+            "biospecimen_pool",
+            "location",
+            "location__parent",
+            "location__parent__parent",
+            "location__parent__parent__parent",
+            "location__parent__parent__parent__parent",
+        ).order_by("-created_at")[:8]
+    ]
+    payload["materials"] = [_inventory_material_to_dict(item) for item in InventoryMaterial.objects.order_by("name")[:8]]
+    payload["lots"] = [
+        _inventory_lot_to_dict(item)
+        for item in InventoryLot.objects.select_related("material", "lab", "storage_location").order_by("-created_at")[:8]
+    ]
+    payload["recent_transactions"] = [
+        _inventory_transaction_to_dict(item)
+        for item in InventoryTransaction.objects.select_related("lot", "lot__material", "location").order_by("-created_at")[:8]
+    ]
+    payload["actions"] = [
+        {
+            "title": "Create storage location",
+            "description": "Build the storage hierarchy one node at a time so facilities, equipment, containers, and positions stay valid.",
+            "href": "/lims/storage/locations/create/",
+            "icon": "add_home_work",
+            "enabled": payload["capabilities"]["can_manage_storage"],
+        },
+        {
+            "title": "Record specimen placement",
+            "description": "Log a biospecimen or pool placement event against the immutable storage history ledger.",
+            "href": "/lims/storage/placements/create/",
+            "icon": "move_item",
+            "enabled": payload["capabilities"]["can_manage_storage"],
+        },
+        {
+            "title": "Create inventory material",
+            "description": "Register consumables, kits, reagents, labels, and other reusable catalog entries.",
+            "href": "/lims/storage/materials/create/",
+            "icon": "inventory_2",
+            "enabled": payload["capabilities"]["can_manage_inventory"],
+        },
+        {
+            "title": "Receive inventory lot",
+            "description": "Capture lot receipt, storage, expiry, and opening stock in one dedicated lot form.",
+            "href": "/lims/storage/lots/create/",
+            "icon": "local_shipping",
+            "enabled": payload["capabilities"]["can_manage_inventory"],
+        },
+        {
+            "title": "Record stock transaction",
+            "description": "Post adjustments, reservations, releases, transfers, consumptions, and disposals to the lot ledger.",
+            "href": "/lims/storage/transactions/create/",
+            "icon": "sync_alt",
+            "enabled": payload["capabilities"]["can_manage_inventory"],
+        },
+    ]
+    return payload
+
+
+def _storage_location_create_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-storage",
+        title="Create storage location",
+        summary="Add one storage node at a time so hierarchy validation, lab ownership, and level depth stay predictable.",
+        kicker="Storage setup",
+    )
+    payload["lab_options"] = [_model_to_option(item) for item in Lab.objects.order_by("name")]
+    payload["parent_options"] = [
+        {
+            "value": str(item.id),
+            "label": " / ".join(node["code"] for node in _storage_location_path(item)),
+            "lab_id": str(item.lab_id),
+            "level": item.level,
+        }
+        for item in StorageLocation.objects.select_related(
+            "parent",
+            "parent__parent",
+            "parent__parent__parent",
+            "parent__parent__parent__parent",
+        ).order_by("lab__name", "level", "name")
+    ]
+    payload["level_options"] = [{"value": value, "label": label} for value, label in StorageLocation.Level.choices]
+    payload["temperature_zone_options"] = [{"value": "", "label": "None"}] + [
+        {"value": value, "label": label} for value, label in StorageLocation.TemperatureZone.choices
+    ]
+    return payload
+
+
+def _storage_placement_create_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-storage",
+        title="Record specimen placement",
+        summary="Choose a biospecimen or pool, select the destination storage location, and append a new immutable placement record.",
+        kicker="Placement logging",
+    )
+    payload["specimen_options"] = [
+        {"value": str(item.id), "label": f"{item.sample_identifier} ({item.status})"}
+        for item in Biospecimen.objects.order_by("-created_at")[:100]
+    ]
+    payload["pool_options"] = [
+        {"value": str(item.id), "label": f"{item.pool_identifier} ({item.status})"}
+        for item in BiospecimenPool.objects.order_by("-created_at")[:100]
+    ]
+    payload["location_options"] = [
+        {
+            "value": str(item.id),
+            "label": " / ".join(node["code"] for node in _storage_location_path(item)),
+            "lab_id": str(item.lab_id),
+        }
+        for item in StorageLocation.objects.select_related(
+            "parent",
+            "parent__parent",
+            "parent__parent__parent",
+            "parent__parent__parent__parent",
+        ).order_by("lab__name", "level", "name")
+    ]
+    payload["reason_options"] = [{"value": value, "label": label} for value, label in BiospecimenStorageRecord.Reason.choices]
+    payload["recent_records"] = [
+        _biospecimen_storage_record_to_dict(item)
+        for item in BiospecimenStorageRecord.objects.select_related(
+            "biospecimen",
+            "biospecimen_pool",
+            "location",
+            "location__parent",
+            "location__parent__parent",
+            "location__parent__parent__parent",
+            "location__parent__parent__parent__parent",
+        ).order_by("-created_at")[:8]
+    ]
+    return payload
+
+
+def _inventory_material_create_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-storage",
+        title="Create inventory material",
+        summary="Register one catalog material at a time so later lot receipt and stock transactions reuse the same controlled entry.",
+        kicker="Inventory catalog",
+    )
+    payload["category_options"] = [{"value": value, "label": label} for value, label in InventoryMaterial.Category.choices]
+    payload["recent_materials"] = [_inventory_material_to_dict(item) for item in InventoryMaterial.objects.order_by("name")[:10]]
+    return payload
+
+
+def _inventory_lot_create_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-storage",
+        title="Receive inventory lot",
+        summary="Capture lot receipt, stock quantity, storage assignment, and expiry information from one focused inventory form.",
+        kicker="Lot receipt",
+    )
+    payload["material_options"] = [
+        {"value": str(item.id), "label": f"{item.name} ({item.code})"}
+        for item in InventoryMaterial.objects.order_by("name")
+    ]
+    payload["lab_options"] = [_model_to_option(item) for item in Lab.objects.order_by("name")]
+    payload["storage_location_options"] = [
+        {
+            "value": str(item.id),
+            "label": " / ".join(node["code"] for node in _storage_location_path(item)),
+            "lab_id": str(item.lab_id),
+        }
+        for item in StorageLocation.objects.select_related(
+            "parent",
+            "parent__parent",
+            "parent__parent__parent",
+            "parent__parent__parent__parent",
+        ).order_by("lab__name", "level", "name")
+    ]
+    payload["recent_lots"] = [
+        _inventory_lot_to_dict(item)
+        for item in InventoryLot.objects.select_related("material", "lab", "storage_location").order_by("-created_at")[:8]
+    ]
+    return payload
+
+
+def _inventory_transaction_create_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-storage",
+        title="Record stock transaction",
+        summary="Post a transaction to an inventory lot so on-hand quantity changes remain auditable and tied to a single ledger entry.",
+        kicker="Inventory ledger",
+    )
+    payload["lot_options"] = [
+        {
+            "value": str(item.id),
+            "label": f"{item.material.name} · {item.lot_number} ({item.on_hand_quantity} {item.unit_of_measure or item.material.default_unit})",
+            "lab_id": str(item.lab_id),
+        }
+        for item in InventoryLot.objects.select_related("material").order_by("-created_at")[:100]
+    ]
+    payload["transaction_type_options"] = [
+        {"value": value, "label": label} for value, label in InventoryTransaction.TransactionType.choices
+    ]
+    payload["location_options"] = [
+        {
+            "value": str(item.id),
+            "label": " / ".join(node["code"] for node in _storage_location_path(item)),
+            "lab_id": str(item.lab_id),
+        }
+        for item in StorageLocation.objects.select_related(
+            "parent",
+            "parent__parent",
+            "parent__parent__parent",
+            "parent__parent__parent__parent",
+        ).order_by("lab__name", "level", "name")
+    ]
+    payload["specimen_options"] = [
+        {"value": str(item.id), "label": f"{item.sample_identifier} ({item.status})"}
+        for item in Biospecimen.objects.order_by("-created_at")[:100]
+    ]
+    payload["pool_options"] = [
+        {"value": str(item.id), "label": f"{item.pool_identifier} ({item.status})"}
+        for item in BiospecimenPool.objects.order_by("-created_at")[:100]
+    ]
+    payload["recent_transactions"] = [
+        _inventory_transaction_to_dict(item)
+        for item in InventoryTransaction.objects.select_related("lot", "lot__material", "location").order_by("-created_at")[:8]
     ]
     return payload
 
@@ -2690,6 +2960,89 @@ def lims_processing_page(request):
         request,
         'lims/processing.html',
         _page_context(request, active_nav='lims-processing', payload=_processing_page_payload(request)),
+    )
+
+
+@csrf_exempt
+def lims_storage_inventory_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    if not (_has_permission(request, 'lims.storage.view') or _has_permission(request, 'lims.inventory.view')):
+        return JsonResponse({'error': 'forbidden'}, status=403)
+    return render(
+        request,
+        'lims/storage_inventory.html',
+        _page_context(request, active_nav='lims-storage', payload=_storage_inventory_page_payload(request)),
+    )
+
+
+@csrf_exempt
+def lims_storage_create_location_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.storage.view')
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'lims/storage_create_location.html',
+        _page_context(request, active_nav='lims-storage', payload=_storage_location_create_page_payload(request)),
+    )
+
+
+@csrf_exempt
+def lims_storage_create_placement_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.storage.view')
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'lims/storage_create_placement.html',
+        _page_context(request, active_nav='lims-storage', payload=_storage_placement_create_page_payload(request)),
+    )
+
+
+@csrf_exempt
+def lims_storage_create_material_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.inventory.view')
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'lims/storage_create_material.html',
+        _page_context(request, active_nav='lims-storage', payload=_inventory_material_create_page_payload(request)),
+    )
+
+
+@csrf_exempt
+def lims_storage_create_lot_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.inventory.view')
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'lims/storage_create_lot.html',
+        _page_context(request, active_nav='lims-storage', payload=_inventory_lot_create_page_payload(request)),
+    )
+
+
+@csrf_exempt
+def lims_storage_create_transaction_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.inventory.view')
+    if forbidden:
+        return forbidden
+    return render(
+        request,
+        'lims/storage_create_transaction.html',
+        _page_context(request, active_nav='lims-storage', payload=_inventory_transaction_create_page_payload(request)),
     )
 
 

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -66,6 +66,12 @@ def test_lims_html_pages_render_with_role_aware_actions():
         ("/lims/receiving/batch/", b"Receive batch manifest", b'data-lims-action="receiving-manifest-create"'),
         ("/lims/receiving/edc-import/", b"Retrieve metadata from EDC", b'data-lims-action="receiving-edc-import"'),
         ("/lims/processing/", b"Batch and plate processing", b'data-lims-action="processing-batch-create"'),
+        ("/lims/storage/", b"Storage and inventory administration", b"Choose a storage or inventory workflow"),
+        ("/lims/storage/locations/create/", b"Create storage location", b'data-lims-action="storage-location-create"'),
+        ("/lims/storage/placements/create/", b"Record specimen placement", b'data-lims-action="storage-placement-create"'),
+        ("/lims/storage/materials/create/", b"Create inventory material", b'data-lims-action="inventory-material-create"'),
+        ("/lims/storage/lots/create/", b"Receive inventory lot", b'data-lims-action="inventory-lot-create"'),
+        ("/lims/storage/transactions/create/", b"Record stock transaction", b'data-lims-action="inventory-transaction-create"'),
     ]
 
     for path, title, action_marker in pages:
@@ -303,3 +309,40 @@ def test_receiving_pages_show_qc_storage_and_import_workflows():
     assert b"External ID to import" in edc_page.content
     assert b"Receiving date" in edc_page.content
     assert b"Brought by" in edc_page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_storage_inventory_pages_show_admin_forms():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-storage")
+
+    launchpad = client.get("/lims/storage/", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin")
+    assert launchpad.status_code == 200
+    assert b"Storage and inventory administration" in launchpad.content
+    assert b"Create storage location" in launchpad.content
+    assert b"Record stock transaction" in launchpad.content
+
+    location_page = client.get("/lims/storage/locations/create/", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin")
+    assert location_page.status_code == 200
+    assert b"Temperature zone" in location_page.content
+    assert b"Metadata JSON" in location_page.content
+
+    placement_page = client.get("/lims/storage/placements/create/", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin")
+    assert placement_page.status_code == 200
+    assert b"Immutable storage history" in placement_page.content
+    assert b"Quantity snapshot" in placement_page.content
+
+    material_page = client.get("/lims/storage/materials/create/", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin")
+    assert material_page.status_code == 200
+    assert b"Default unit" in material_page.content
+    assert b"Create inventory material" in material_page.content
+
+    lot_page = client.get("/lims/storage/lots/create/", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin")
+    assert lot_page.status_code == 200
+    assert b"Lot number" in lot_page.content
+    assert b"Initial quantity" in lot_page.content
+
+    transaction_page = client.get("/lims/storage/transactions/create/", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin")
+    assert transaction_page.status_code == 200
+    assert b"Transaction type" in transaction_page.content
+    assert b"Linked biospecimen" in transaction_page.content


### PR DESCRIPTION
## Summary
- add a `/lims/storage/` launchpad and dedicated task pages for locations, placements, materials, lots, and transactions
- wire storage/inventory navigation into the LIMS dashboard and shell, and document the new admin UI surface
- extend `src/tests/test_lims_ui.py` to cover the new storage pages and action markers

## Validation
- `cd src && ../.venv/bin/python manage.py check`
- `./.venv/bin/python -m pytest -q src/tests/test_lims_ui.py` *(blocked locally: PostgreSQL test DB on `localhost:5432` / `mtafiti_test` was unavailable in this environment)*
