### PR TITLE
feat: finish operator task inbox UI (#84)

### DIFF
--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -166,6 +166,8 @@ from lims.views import (
     lims_storage_create_placement_page,
     lims_storage_create_transaction_page,
     lims_storage_inventory_page,
+    lims_task_detail_page,
+    lims_task_inbox_page,
 )
 from tenants.views import tenant_services, tenants
 
@@ -179,6 +181,12 @@ urlpatterns = [
     path('api/v1/tenants/services', tenant_services, name='tenant_services'),
     path('api/v1/lims/', include(('lims.urls', 'lims'), namespace='lims')),
     path('lims/', lims_dashboard_page, name='lims_dashboard_page'),
+    path('lims/tasks/', lims_task_inbox_page, name='lims_task_inbox_page'),
+    path(
+        'lims/operations/<uuid:operation_id>/runs/<uuid:run_id>/tasks/<uuid:task_id>/',
+        lims_task_detail_page,
+        name='lims_task_detail_page',
+    ),
     path('lims/reference/', lims_reference_page, name='lims_reference_page'),
     path(
         'lims/reference/operations/sample-accession/',

--- a/src/lims/templates/lims/task_detail.html
+++ b/src/lims/templates/lims/task_detail.html
@@ -1,0 +1,223 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Tasks" parent_url="/lims/tasks/" current_label=payload.task.title %}
+{{ payload.task_json|json_script:"lims-task-runtime" }}
+
+<div class="stat-grid">
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Task status" count_label=payload.task.node_key count_value=payload.task.status %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Run status" count_label=payload.task.operation_name count_value=payload.task.operation_run_status %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Submissions" count_label="captured attempts" count_value=payload.task.submissions|length %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Approvals" count_label="review records" count_value=payload.task.approvals|length %}
+</div>
+
+<section class="panel" data-lims-action="task-detail">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Task context" panel_description="This page keeps the governed runtime identifiers, current source context, and the recommended task-entry surface together." %}
+  <div class="section-stack">
+    <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));">
+      <article class="card">
+        <h2 class="panel-title">Operation</h2>
+        <p>{{ payload.task.operation_name }} · {{ payload.task.operation_code }}</p>
+        <p class="muted">Run {{ payload.task.operation_run_id }}</p>
+      </article>
+      <article class="card">
+        <h2 class="panel-title">Subject + source</h2>
+        <p>Subject: {{ payload.task.subject_identifier|default:"-" }}</p>
+        <p>Source: {{ payload.task.source_mode }}{% if payload.task.source_reference %} · {{ payload.task.source_reference }}{% endif %}</p>
+      </article>
+      <article class="card">
+        <h2 class="panel-title">Assignment</h2>
+        <p>Role: {{ payload.task.assignment_role|default:"-" }}</p>
+        <p>Assignee: {{ payload.task.assignee|default:"Available" }}</p>
+      </article>
+      <article class="card">
+        <h2 class="panel-title">Approval</h2>
+        <p>{% if payload.task.requires_approval %}Required · {{ payload.task.approval_role }}{% else %}Not required{% endif %}</p>
+        <p>Current outcome: {{ payload.task.outcome|default:"-" }}</p>
+      </article>
+    </div>
+    <div class="button-row">
+      <a class="button button-secondary" href="/lims/tasks/">Back to inbox</a>
+      {% if payload.task.adapter_surface %}
+      <a class="button button-secondary" href="{{ payload.task.adapter_surface }}">Open receiving {{ payload.task.source_mode|default:"workflow" }} surface</a>
+      {% endif %}
+    </div>
+  </div>
+</section>
+
+{% if payload.task.can_submit %}
+<section class="panel" data-lims-action="task-submit">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Submit runtime payload" panel_description="Use the governed task endpoint directly from the inbox. The textarea is prefilled from the latest submission when one exists." %}
+  <div class="section-stack">
+    <p class="muted">Runtime submit endpoint: <code>{{ payload.task.submit_url }}</code></p>
+    <label class="field-group">
+      <span class="field-label">Submission payload JSON</span>
+      <textarea class="textarea" rows="12" data-lims-field="task-submission-json">{{ payload.default_submission_json }}</textarea>
+    </label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="submitCurrentTask()"><span class="material-symbols-outlined button-icon" aria-hidden="true">task_alt</span><span>Submit task payload</span></button>
+      {% if payload.task.adapter_surface %}
+      <a class="button button-secondary" href="{{ payload.task.adapter_surface }}">Use transitional capture page</a>
+      {% endif %}
+    </div>
+  </div>
+</section>
+{% endif %}
+
+{% if payload.task.can_approve %}
+<section class="panel" data-lims-action="task-approve">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Approve or reopen task" panel_description="QA and governance reviewers can approve the task to advance the run or reject it to reopen the step." %}
+  <div class="section-stack">
+    <p class="muted">Runtime approval endpoint: <code>{{ payload.task.approve_url }}</code></p>
+    <div class="field-grid field-grid--wide">
+      <label class="field-group">
+        <span class="field-label">Outcome</span>
+        <select class="select" data-lims-field="task-approval-outcome">
+          <option value="approved">Approved</option>
+          <option value="rejected">Rejected</option>
+        </select>
+      </label>
+      <label class="field-group">
+        <span class="field-label">Meaning</span>
+        <input class="input" data-lims-field="task-approval-meaning" value="QA review completed" />
+      </label>
+    </div>
+    <label class="field-group">
+      <span class="field-label">Comments</span>
+      <textarea class="textarea" rows="4" data-lims-field="task-approval-comments"></textarea>
+    </label>
+    <div class="button-row">
+      <button class="button" type="button" onclick="approveCurrentTask()"><span class="material-symbols-outlined button-icon" aria-hidden="true">verified</span><span>Submit approval</span></button>
+    </div>
+  </div>
+</section>
+{% endif %}
+
+<div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
+  <section class="panel">
+    {% include "core/ui/includes/panel_header.html" with panel_title="Submission history" panel_description="Every payload captured for this task in submission order." %}
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>#</th><th>Status</th><th>Submitted by</th><th>Payload</th></tr></thead>
+        <tbody>
+          {% for item in payload.task.submissions %}
+          <tr>
+            <td>{{ item.submission_index }}</td>
+            <td>{{ item.status }}</td>
+            <td>{{ item.submitted_by|default:"-" }}</td>
+            <td><code>{{ item.payload }}</code></td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="4">No submissions have been recorded for this task yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section class="panel">
+    {% include "core/ui/includes/panel_header.html" with panel_title="Approval history" panel_description="QA or governance decisions recorded against this workflow step." %}
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Outcome</th><th>Approver</th><th>Role</th><th>Meaning</th></tr></thead>
+        <tbody>
+          {% for item in payload.task.approvals %}
+          <tr>
+            <td>{{ item.outcome }}</td>
+            <td>{{ item.approved_by|default:"-" }}</td>
+            <td>{{ item.approver_role|default:"-" }}</td>
+            <td>{{ item.meaning|default:"-" }}</td>
+          </tr>
+          {% empty %}
+          <tr><td colspan="4">No approvals have been recorded for this task yet.</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Current workflow state" panel_description="Sibling tasks in this operation run, including newly opened work created after each transition." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Task</th><th>Status</th><th>Outcome</th><th>Action</th></tr></thead>
+      <tbody>
+        {% for item in payload.operation_run.tasks %}
+        <tr>
+          <td>{{ item.title }}</td>
+          <td>{{ item.status }}</td>
+          <td>{{ item.outcome|default:"-" }}</td>
+          <td>
+            {% if item.id == payload.task.id %}
+            Current task
+            {% elif item.status == "open" or item.status == "awaiting_approval" %}
+            <a href="/lims/operations/{{ payload.task.operation_definition_id }}/runs/{{ payload.task.operation_run_id }}/tasks/{{ item.id }}/">Open task →</a>
+            {% else %}
+            -
+            {% endif %}
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}
+
+{% block extra_scripts %}
+{{ block.super }}
+const limsTaskRuntime = JSON.parse(document.getElementById("lims-task-runtime").textContent);
+
+function limsTaskRedirect(url, message, isError) {
+  const target = new URL(url, window.location.origin);
+  if (message) {
+    target.searchParams.set("ui_message", message);
+    target.searchParams.set("ui_error", isError ? "1" : "0");
+  }
+  window.location.assign(target.toString());
+}
+
+function limsNextTaskUrl(runPayload) {
+  const tasks = (runPayload && runPayload.tasks) || [];
+  const nextTask = tasks.find((item) => (item.status === "open" || item.status === "awaiting_approval") && item.id !== limsTaskRuntime.id);
+  if (!nextTask) {
+    return "";
+  }
+  return `/lims/operations/${runPayload.operation_definition_id}/runs/${runPayload.id}/tasks/${nextTask.id}/`;
+}
+
+async function submitCurrentTask() {
+  let payload;
+  try {
+    payload = JSON.parse(limsValue("task-submission-json") || "{}");
+  } catch (_error) {
+    limsFeedback("task-submission-json must be valid JSON", true);
+    return;
+  }
+  let runPayload;
+  try {
+    runPayload = await limsPortalRequest(limsTaskRuntime.submit_url, {payload}, "POST");
+  } catch (error) {
+    limsFeedback(error.message || "Task submission failed", true);
+    return;
+  }
+  limsTaskRedirect(limsNextTaskUrl(runPayload) || "/lims/tasks/", "Task submitted", false);
+}
+
+async function approveCurrentTask() {
+  const payload = {
+    outcome: limsValue("task-approval-outcome"),
+    meaning: limsValue("task-approval-meaning"),
+    comments: limsValue("task-approval-comments"),
+  };
+  let runPayload;
+  try {
+    runPayload = await limsPortalRequest(limsTaskRuntime.approve_url, payload, "POST");
+  } catch (error) {
+    limsFeedback(error.message || "Task approval failed", true);
+    return;
+  }
+  limsTaskRedirect(limsNextTaskUrl(runPayload) || "/lims/tasks/", "Task approval recorded", false);
+}
+{% endblock %}

--- a/src/lims/templates/lims/task_inbox.html
+++ b/src/lims/templates/lims/task_inbox.html
@@ -1,0 +1,106 @@
+{% extends "lims/base.html" %}
+
+{% block content %}
+{% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="LIMS" parent_url="/lims/" current_label="Tasks" %}
+
+<div class="stat-grid">
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Open tasks" count_label="ready to execute" count_value=payload.cards.open_tasks %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Approvals" count_label="awaiting review" count_value=payload.cards.approval_tasks %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Assigned to you" count_label="claimed items" count_value=payload.cards.assigned_tasks %}
+  {% include "core/ui/includes/count_stat_card.html" with card_title="Recent outcomes" count_label="completed or closed runs" count_value=payload.cards.recent_outcomes %}
+</div>
+
+<section class="panel" data-lims-action="task-inbox">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Task inbox workflows" panel_description="Use the inbox as the main follow-up surface, while transitional receiving pages remain available for task entry when a node advertises an adapter surface." %}
+  <div class="cards">
+    {% for item in payload.actions %}
+    <article class="card">
+      <div class="panel-header">
+        <div>
+          <h2 class="panel-title">{{ item.title }}</h2>
+          <p class="panel-description">{{ item.description }}</p>
+        </div>
+        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
+      </div>
+      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
+    </article>
+    {% endfor %}
+  </div>
+</section>
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Actionable tasks" panel_description="Open workflow work items you can execute now, including available items and any work already assigned to your user." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Task</th><th>Operation</th><th>Subject</th><th>Source</th><th>Status</th><th>Assignment</th><th>Action</th></tr></thead>
+      <tbody>
+        {% for item in payload.open_tasks %}
+        <tr>
+          <td>
+            <strong>{{ item.title }}</strong>
+            <div class="muted">{{ item.summary|default:item.node_key }}</div>
+          </td>
+          <td>{{ item.operation_name }}</td>
+          <td>{{ item.subject_identifier|default:"-" }}</td>
+          <td>{{ item.source_mode }}{% if item.source_reference %} · {{ item.source_reference }}{% endif %}</td>
+          <td>{{ item.status }}</td>
+          <td>{% if item.is_assigned_to_user %}Assigned to you{% elif item.assignee %}{{ item.assignee }}{% else %}Available{% endif %}</td>
+          <td><a href="{{ item.page_url }}">{{ item.action_label }} →</a></td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="7">No executable workflow tasks are currently available for your role.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Approval queue" panel_description="Tasks that have been submitted and are now waiting for QA or governance review." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Task</th><th>Operation</th><th>Outcome</th><th>Approval role</th><th>Submitted by</th><th>Action</th></tr></thead>
+      <tbody>
+        {% for item in payload.approval_tasks %}
+        <tr>
+          <td>
+            <strong>{{ item.title }}</strong>
+            <div class="muted">{{ item.summary|default:item.node_key }}</div>
+          </td>
+          <td>{{ item.operation_name }}</td>
+          <td>{{ item.outcome|default:"-" }}</td>
+          <td>{{ item.approval_role|default:"-" }}</td>
+          <td>{% if item.latest_submission %}{{ item.latest_submission.submitted_by|default:"-" }}{% else %}-{% endif %}</td>
+          <td><a href="{{ item.page_url }}">{{ item.action_label }} →</a></td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="6">No approval tasks are waiting for your review.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<section class="panel">
+  {% include "core/ui/includes/panel_header.html" with panel_title="Recent operation outcomes" panel_description="Latest completed, rejected, or cancelled runs so operators and managers can see what just finished." %}
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Operation</th><th>Status</th><th>Source</th><th>Subject</th><th>Outcome</th><th>Started</th></tr></thead>
+      <tbody>
+        {% for item in payload.recent_runs %}
+        <tr>
+          <td>{{ item.operation_name }}</td>
+          <td>{{ item.status }}</td>
+          <td>{{ item.source_mode }}</td>
+          <td>{{ item.subject_identifier|default:"-" }}</td>
+          <td>{{ item.outcome|default:"-" }}</td>
+          <td>{{ item.started_at|default:"-" }}</td>
+        </tr>
+        {% empty %}
+        <tr><td colspan="6">No completed or closed operation runs yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/src/lims/views.py
+++ b/src/lims/views.py
@@ -157,6 +157,7 @@ def _lims_navigation(request, active_key: str) -> dict[str, object]:
     links = []
     candidates = [
         ("lims-dashboard", "Dashboard", "dashboard", "/lims/", "lims.dashboard.view"),
+        ("lims-tasks", "Tasks", "task", "/lims/tasks/", "lims.workflow_task.view"),
         ("lims-reference", "Reference", "globe_location_pin", "/lims/reference/", "lims.reference.view"),
         ("lims-metadata", "Metadata", "schema", "/lims/metadata/", "lims.metadata.view"),
         ("lims-biospecimens", "Biospecimens", "biotech", "/lims/biospecimens/", "lims.artifact.view"),
@@ -199,12 +200,14 @@ def _page_payload_base(request, *, active_key: str, title: str, summary: str, ki
             "can_manage_operations": _has_permission(request, "lims.operation.manage"),
             "can_view_operation_runs": _has_permission(request, "lims.operation_run.view"),
             "can_manage_operation_runs": _has_permission(request, "lims.operation_run.manage"),
+            "can_view_tasks": _has_permission(request, "lims.workflow_task.view"),
+            "can_execute_tasks": _has_permission(request, "lims.workflow_task.execute"),
+            "can_assign_tasks": _has_permission(request, "lims.workflow_task.assign"),
+            "can_approve_tasks": _has_permission(request, "lims.workflow_task.approve"),
             "can_view_storage": _has_permission(request, "lims.storage.view"),
             "can_manage_storage": _has_permission(request, "lims.storage.manage"),
             "can_view_inventory": _has_permission(request, "lims.inventory.view"),
             "can_manage_inventory": _has_permission(request, "lims.inventory.manage"),
-            "can_execute_tasks": _has_permission(request, "lims.workflow.execute"),
-            "can_approve_tasks": _has_permission(request, "lims.workflow.approve"),
         },
         "page": {
             "page_title": title,
@@ -249,6 +252,12 @@ def _dashboard_payload(request) -> dict[str, object]:
         "storage_locations": storage_location_count,
     }
     payload["launchpad"] = [
+        {
+            "title": "Task inbox",
+            "description": "Review open runtime work, approval queues, and the next governed step for each operation run.",
+            "href": "/lims/tasks/",
+            "status": "ready" if payload["capabilities"]["can_view_tasks"] else "restricted",
+        },
         {
             "title": "Reference data",
             "description": "Manage labs, studies, sites, and address sync runs for the tenant.",
@@ -302,6 +311,192 @@ def _dashboard_payload(request) -> dict[str, object]:
         _biospecimen_to_dict(item)
         for item in Biospecimen.objects.select_related("sample_type").order_by("-created_at")[:5]
     ]
+    return payload
+
+
+def _task_run_queryset():
+    return TaskRun.objects.select_related(
+        "operation_run__operation_version__definition",
+        "operation_run__workflow_version__template",
+        "operation_run__biospecimen",
+        "operation_run__manifest",
+        "operation_run__manifest_item",
+        "node_template",
+    ).prefetch_related("submissions", "approvals")
+
+
+def _task_adapter_surface(task_run: TaskRun) -> str:
+    adapter_surface = str(task_run.node_template.config.get("adapter_surface") or "").strip()
+    if adapter_surface != "/lims/receiving/":
+        return adapter_surface
+    if task_run.operation_run.source_mode == OperationRun.SourceMode.BATCH:
+        return "/lims/receiving/batch/"
+    if task_run.operation_run.source_mode == OperationRun.SourceMode.EDC_IMPORT:
+        return "/lims/receiving/edc-import/"
+    return "/lims/receiving/single/"
+
+
+def _task_page_url(task_run: TaskRun) -> str:
+    return (
+        f"/lims/operations/{task_run.operation_run.operation_version.definition_id}/runs/"
+        f"{task_run.operation_run_id}/tasks/{task_run.id}/"
+    )
+
+
+def _can_execute_task(request, task_run: TaskRun, *, user_id: str) -> bool:
+    if task_run.status != TaskRun.Status.OPEN:
+        return False
+    permission_key = task_run.permission_key or "lims.workflow_task.execute"
+    if not _has_permission(request, permission_key):
+        return False
+    if task_run.assignee and task_run.assignee != user_id:
+        return _has_permission(request, "lims.workflow_task.assign") or _has_permission(request, "lims.operation_run.manage")
+    return True
+
+
+def _can_approve_task(request, task_run: TaskRun) -> bool:
+    if task_run.status != TaskRun.Status.AWAITING_APPROVAL:
+        return False
+    return _has_permission(request, "lims.workflow_task.approve")
+
+
+def _task_run_ui_dict(request, task_run: TaskRun, *, user_id: str) -> dict[str, object]:
+    latest_submission = task_run.submissions.order_by("-submission_index").first()
+    latest_approval = task_run.approvals.order_by("-approved_at", "-created_at").first()
+    can_submit = _can_execute_task(request, task_run, user_id=user_id)
+    can_approve = _can_approve_task(request, task_run)
+    action_mode = "approve" if can_approve else "submit" if can_submit else "view"
+    return {
+        "id": str(task_run.id),
+        "operation_run_id": str(task_run.operation_run_id),
+        "operation_definition_id": str(task_run.operation_run.operation_version.definition_id),
+        "operation_code": task_run.operation_run.operation_version.definition.code,
+        "operation_name": task_run.operation_run.operation_version.definition.name,
+        "operation_run_status": task_run.operation_run.status,
+        "workflow_template_code": task_run.operation_run.workflow_version.template.code,
+        "node_key": task_run.node_template.node_key,
+        "node_type": task_run.node_template.node_type,
+        "title": task_run.node_template.title,
+        "summary": task_run.node_template.summary,
+        "status": task_run.status,
+        "assignment_role": task_run.assignment_role,
+        "assignee": task_run.assignee,
+        "permission_key": task_run.permission_key,
+        "requires_approval": task_run.requires_approval,
+        "approval_role": task_run.approval_role,
+        "outcome": task_run.outcome,
+        "source_mode": task_run.operation_run.source_mode,
+        "source_reference": task_run.operation_run.source_reference,
+        "subject_identifier": task_run.operation_run.subject_identifier,
+        "external_identifier": task_run.operation_run.external_identifier,
+        "biospecimen_id": str(task_run.operation_run.biospecimen_id) if task_run.operation_run.biospecimen_id else None,
+        "manifest_id": str(task_run.operation_run.manifest_id) if task_run.operation_run.manifest_id else None,
+        "manifest_item_id": str(task_run.operation_run.manifest_item_id) if task_run.operation_run.manifest_item_id else None,
+        "started_at": task_run.started_at.isoformat() if task_run.started_at else None,
+        "completed_at": task_run.completed_at.isoformat() if task_run.completed_at else None,
+        "input_context": dict(task_run.input_context or {}),
+        "output_data": dict(task_run.output_data or {}),
+        "config": dict(task_run.node_template.config or {}),
+        "page_url": _task_page_url(task_run),
+        "submit_url": (
+            f"/api/v1/lims/operations/{task_run.operation_run.operation_version.definition_id}/runs/"
+            f"{task_run.operation_run_id}/tasks/{task_run.id}/submit"
+        ),
+        "approve_url": (
+            f"/api/v1/lims/operations/{task_run.operation_run.operation_version.definition_id}/runs/"
+            f"{task_run.operation_run_id}/tasks/{task_run.id}/approve"
+        ),
+        "adapter_surface": _task_adapter_surface(task_run),
+        "is_assigned_to_user": bool(user_id and task_run.assignee == user_id),
+        "can_submit": can_submit,
+        "can_approve": can_approve,
+        "action_mode": action_mode,
+        "action_label": "Review approval" if can_approve else "Open task" if can_submit else "View details",
+        "latest_submission": _submission_record_to_dict(latest_submission) if latest_submission else None,
+        "latest_approval": _approval_record_to_dict(latest_approval) if latest_approval else None,
+        "submissions": [_submission_record_to_dict(item) for item in task_run.submissions.order_by("submission_index")],
+        "approvals": [_approval_record_to_dict(item) for item in task_run.approvals.order_by("approved_at", "created_at")],
+    }
+
+
+def _task_inbox_page_payload(request) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-tasks",
+        title="Workflow task inbox",
+        summary="Follow governed operation work from one inbox that separates executable tasks, approval queues, and recent outcomes.",
+        kicker="Operator task inbox",
+    )
+    user_id = str(_user_context(request)["user_id"])
+    task_items = [
+        _task_run_ui_dict(request, item, user_id=user_id)
+        for item in _task_run_queryset().filter(
+            status__in=[TaskRun.Status.OPEN, TaskRun.Status.AWAITING_APPROVAL]
+        ).order_by("-operation_run__created_at", "node_template__position", "created_at")[:50]
+    ]
+    open_tasks = [item for item in task_items if item["status"] == TaskRun.Status.OPEN and item["can_submit"]]
+    approval_tasks = [item for item in task_items if item["status"] == TaskRun.Status.AWAITING_APPROVAL and item["can_approve"]]
+    assigned_tasks = [item for item in open_tasks if item["is_assigned_to_user"]]
+    payload["cards"] = {
+        "open_tasks": len(open_tasks),
+        "approval_tasks": len(approval_tasks),
+        "assigned_tasks": len(assigned_tasks),
+        "recent_outcomes": OperationRun.objects.filter(
+            status__in=[OperationRun.Status.COMPLETED, OperationRun.Status.REJECTED, OperationRun.Status.CANCELLED]
+        ).count(),
+    }
+    payload["actions"] = [
+        {
+            "title": "Open receiving",
+            "description": "Use the receiving launchpad while accession intake remains a transitional task-entry surface.",
+            "href": "/lims/receiving/",
+            "icon": "inventory_2",
+        },
+        {
+            "title": "Inspect operations",
+            "description": "Review governed operation bundles and runtime history behind the current inbox items.",
+            "href": "/lims/reference/operations/sample-accession/",
+            "icon": "conversion_path",
+        },
+    ]
+    payload["open_tasks"] = open_tasks
+    payload["approval_tasks"] = approval_tasks
+    payload["recent_runs"] = [
+        _operation_run_to_dict(item)
+        for item in _operation_run_queryset().filter(
+            status__in=[OperationRun.Status.COMPLETED, OperationRun.Status.REJECTED, OperationRun.Status.CANCELLED]
+        ).order_by("-updated_at", "-created_at")[:8]
+    ]
+    return payload
+
+
+def _task_detail_page_payload(request, task_run: TaskRun) -> dict[str, object]:
+    payload = _page_payload_base(
+        request,
+        active_key="lims-tasks",
+        title=task_run.node_template.title,
+        summary="Inspect the governed task context, prior submissions, and the next runtime-backed action for this workflow step.",
+        kicker="Workflow task",
+    )
+    user_id = str(_user_context(request)["user_id"])
+    task_payload = _task_run_ui_dict(request, task_run, user_id=user_id)
+    operation_run = _operation_run_queryset().get(id=task_run.operation_run_id)
+    payload["task"] = task_payload
+    payload["task_json"] = {
+        "id": task_payload["id"],
+        "page_url": task_payload["page_url"],
+        "submit_url": task_payload["submit_url"],
+        "approve_url": task_payload["approve_url"],
+        "source_mode": task_payload["source_mode"],
+        "adapter_surface": task_payload["adapter_surface"],
+        "current_status": task_payload["status"],
+        "default_submission_payload": task_payload["latest_submission"]["payload"] if task_payload["latest_submission"] else {},
+    }
+    payload["default_submission_json"] = json.dumps(payload["task_json"]["default_submission_payload"], indent=2, sort_keys=True)
+    payload["operation_run"] = _operation_run_to_dict(operation_run)
+    payload["current_task_count"] = len(
+        [item for item in payload["operation_run"]["tasks"] if item["status"] in {TaskRun.Status.OPEN, TaskRun.Status.AWAITING_APPROVAL}]
+    )
     return payload
 
 
@@ -3402,6 +3597,38 @@ def lims_dashboard_page(request):
     if forbidden:
         return forbidden
     return render(request, 'lims/dashboard.html', _page_context(request, active_nav='lims-dashboard', payload=_dashboard_payload(request)))
+
+
+@csrf_exempt
+def lims_task_inbox_page(request):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.workflow_task.view')
+    if forbidden:
+        return forbidden
+    return render(request, 'lims/task_inbox.html', _page_context(request, active_nav='lims-tasks', payload=_task_inbox_page_payload(request)))
+
+
+@csrf_exempt
+def lims_task_detail_page(request, operation_id: str, run_id: str, task_id: str):
+    if request.method != 'GET':
+        return JsonResponse({'error': 'method_not_allowed'}, status=405)
+    forbidden = require_lims_permission(request, 'lims.workflow_task.view')
+    if forbidden:
+        return forbidden
+    try:
+        task_run = _task_run_queryset().get(
+            id=task_id,
+            operation_run_id=run_id,
+            operation_run__operation_version__definition_id=operation_id,
+        )
+    except (ValidationError, TaskRun.DoesNotExist):
+        return JsonResponse({'error': 'task_run_not_found'}, status=404)
+    return render(
+        request,
+        'lims/task_detail.html',
+        _page_context(request, active_nav='lims-tasks', payload=_task_detail_page_payload(request, task_run)),
+    )
 
 
 @csrf_exempt

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -42,6 +42,38 @@ def _create_lims_host(client: Client, route_slug: str) -> str:
     return created_route.json()["domain"]
 
 
+def _provision_sample_accession_bundle(client: Client, host: str) -> tuple[str, str]:
+    provisioned = client.post(
+        "/api/v1/lims/reference/operations/sample-accession/provision",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="lims.manager",
+    )
+    assert provisioned.status_code == 200
+    payload = provisioned.json()
+    return payload["operation_definition"]["id"], payload["operation_version"]["id"]
+
+
+def _start_sample_accession_run(client: Client, host: str, *, operation_id: str, operation_version_id: str) -> dict[str, object]:
+    created = client.post(
+        f"/api/v1/lims/operations/{operation_id}/runs",
+        data=json.dumps(
+            {
+                "operation_version_id": operation_version_id,
+                "source_mode": "single",
+                "subject_identifier": "SUBJ-UI-001",
+                "external_identifier": "EXT-UI-001",
+                "context": {"intake_mode": "bench"},
+            }
+        ),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="lims.manager",
+        HTTP_X_USER_ID="manager-1",
+    )
+    assert created.status_code == 201
+    return created.json()
+
+
 @pytest.mark.django_db(transaction=True)
 def test_lims_html_pages_render_with_role_aware_actions():
     client = Client()
@@ -49,6 +81,7 @@ def test_lims_html_pages_render_with_role_aware_actions():
 
     pages = [
         ("/lims/", b"Laboratory operations workspace", None),
+        ("/lims/tasks/", b"Workflow task inbox", b'data-lims-action="task-inbox"'),
         ("/lims/reference/", b"Reference and geography", b"Choose a reference workflow"),
         ("/lims/reference/operations/sample-accession/", b"Sample accession reference bundle", b'data-lims-action="reference-sample-accession-provision"'),
         ("/lims/reference/labs/create/", b"Create lab", b'data-lims-action="reference-lab-create"'),
@@ -276,6 +309,86 @@ def test_reference_sample_accession_page_shows_bundle_status_after_provision():
     assert b"Published v1" in page.content
     assert b"sample-accession-package" in page.content
     assert b"single, batch, edc_import" in page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_task_inbox_lists_actionable_operator_work_and_links_to_runtime_detail(monkeypatch):
+    monkeypatch.setenv("EDMP_ENFORCE_ROLES", "true")
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-task-inbox")
+    operation_id, operation_version_id = _provision_sample_accession_bundle(client, host)
+    run = _start_sample_accession_run(client, host, operation_id=operation_id, operation_version_id=operation_version_id)
+    intake_task = next(item for item in run["tasks"] if item["node_key"] == "intake_capture")
+
+    inbox = client.get("/lims/tasks/", HTTP_HOST=host, HTTP_X_USER_ROLES="lims.operator", HTTP_X_USER_ID="operator-1")
+
+    assert inbox.status_code == 200
+    assert b"Workflow task inbox" in inbox.content
+    assert b"Intake capture" in inbox.content
+    assert b"SUBJ-UI-001" in inbox.content
+    assert f"/lims/operations/{operation_id}/runs/{run['id']}/tasks/{intake_task['id']}/".encode() in inbox.content
+
+    detail = client.get(
+        f"/lims/operations/{operation_id}/runs/{run['id']}/tasks/{intake_task['id']}/",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="lims.operator",
+        HTTP_X_USER_ID="operator-1",
+    )
+
+    assert detail.status_code == 200
+    assert b"Submit runtime payload" in detail.content
+    assert b"/api/v1/lims/operations/" in detail.content
+    assert b"Open receiving single surface" in detail.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_task_inbox_shows_approval_queue_for_review_roles(monkeypatch):
+    monkeypatch.setenv("EDMP_ENFORCE_ROLES", "true")
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-task-approvals")
+    operation_id, operation_version_id = _provision_sample_accession_bundle(client, host)
+    run = _start_sample_accession_run(client, host, operation_id=operation_id, operation_version_id=operation_version_id)
+    intake_task = next(item for item in run["tasks"] if item["node_key"] == "intake_capture")
+
+    intake_submitted = client.post(
+        f"/api/v1/lims/operations/{operation_id}/runs/{run['id']}/tasks/{intake_task['id']}/submit",
+        data=json.dumps({"payload": {"subject_identifier": "SUBJ-UI-001", "received_at": "2026-03-21"}}),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="lims.operator",
+        HTTP_X_USER_ID="operator-1",
+    )
+    assert intake_submitted.status_code == 200
+    qc_task = next(item for item in intake_submitted.json()["tasks"] if item["node_key"] == "qc_decision")
+
+    qc_submitted = client.post(
+        f"/api/v1/lims/operations/{operation_id}/runs/{run['id']}/tasks/{qc_task['id']}/submit",
+        data=json.dumps({"payload": {"qc_decision": "accept", "qc_notes": "Looks good"}}),
+        content_type="application/json",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="lims.operator",
+        HTTP_X_USER_ID="operator-1",
+    )
+    assert qc_submitted.status_code == 200
+
+    inbox = client.get("/lims/tasks/", HTTP_HOST=host, HTTP_X_USER_ROLES="lims.qa", HTTP_X_USER_ID="qa-1")
+
+    assert inbox.status_code == 200
+    assert b"Approval queue" in inbox.content
+    assert b"QC decision" in inbox.content
+    assert f"/lims/operations/{operation_id}/runs/{run['id']}/tasks/{qc_task['id']}/".encode() in inbox.content
+
+    detail = client.get(
+        f"/lims/operations/{operation_id}/runs/{run['id']}/tasks/{qc_task['id']}/",
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="lims.qa",
+        HTTP_X_USER_ID="qa-1",
+    )
+
+    assert detail.status_code == 200
+    assert b"Approve or reopen task" in detail.content
+    assert b"Submit approval" in detail.content
+    assert b"Runtime approval endpoint" in detail.content
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
## Summary
- add `/lims/tasks/` inbox and task detail pages within the existing LIMS admin-style shell
- surface runtime-backed task submit/approve actions plus submission and approval history
- cover operator inbox and QA approval flows with focused LIMS UI tests

## Testing
- `cd src && ../.venv/bin/python manage.py check`
- `./.venv/bin/python -m pytest -q src/tests/test_lims_ui.py`

Closes #84
