### PR TITLE
Issue 135: resolve operation page action cards

### DIFF
--- a/src/core/navigation.py
+++ b/src/core/navigation.py
@@ -18,6 +18,8 @@ class ShellResolutionContext:
     tenant_schema: str
     user_id: str
     roles: frozenset[str]
+    page_states: frozenset[str]
+    data_facts: Mapping[str, Any]
 
 
 ResolutionGate = Callable[[ShellResolutionContext], bool]
@@ -63,12 +65,31 @@ class ActionDescriptor:
     workflow_key: str | None = None
     permission_gate: ResolutionGate | None = None
     enabled_gate: ResolutionGate | None = None
+    data_gate: ResolutionGate | None = None
     status: str | None = None
+    sequence: int | None = None
+    primary_action: bool = False
+    required_states: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if bool(self.route_name) == bool(self.workflow_key):
             raise ValueError(
                 "action descriptors must define exactly one of route_name or workflow_key"
+            )
+
+
+@dataclass(frozen=True)
+class OperationPageDescriptor:
+    key: str
+    title: str
+    route_name: str | None = None
+    navigation_key: str | None = None
+    action_descriptors: tuple[ActionDescriptor, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.route_name and not self.navigation_key:
+            raise ValueError(
+                "operation pages must define at least one of route_name or navigation_key"
             )
 
 
@@ -577,6 +598,8 @@ def build_resolution_context(
     *,
     page_key: str | None = None,
     route_name: str | None = None,
+    page_states: Iterable[str] | None = None,
+    data_facts: Mapping[str, Any] | None = None,
 ) -> ShellResolutionContext:
     tenant = getattr(request, "tenant", None)
     return ShellResolutionContext(
@@ -586,6 +609,8 @@ def build_resolution_context(
         tenant_schema=getattr(tenant, "schema_name", "public"),
         user_id=(request.headers.get("X-User-Id") or "anonymous").strip(),
         roles=frozenset(request_roles(request)),
+        page_states=frozenset(page_states or ()),
+        data_facts=dict(data_facts or {}),
     )
 
 
@@ -676,22 +701,81 @@ def resolve_action_descriptors(
     descriptors: Iterable[ActionDescriptor],
     page_key: str | None = None,
     route_name: str | None = None,
+    page_states: Iterable[str] | None = None,
+    data_facts: Mapping[str, Any] | None = None,
+    workflow_entries: Mapping[str, WorkflowEntry] | None = None,
+) -> list[dict[str, Any]]:
+    return resolve_operation_cards(
+        request,
+        descriptors=descriptors,
+        page_key=page_key,
+        route_name=route_name,
+        page_states=page_states,
+        data_facts=data_facts,
+        workflow_entries=workflow_entries,
+    )
+
+
+def resolve_operation_page(
+    request: HttpRequest,
+    *,
+    descriptor: OperationPageDescriptor,
+    page_states: Iterable[str] | None = None,
+    data_facts: Mapping[str, Any] | None = None,
+    allowed_action_payloads: Iterable[Mapping[str, Any]] | None = None,
+    workflow_entries: Mapping[str, WorkflowEntry] | None = None,
+) -> dict[str, Any]:
+    return {
+        "key": descriptor.key,
+        "title": descriptor.title,
+        "route_name": descriptor.route_name,
+        "navigation_key": descriptor.navigation_key,
+        "action_cards": resolve_operation_cards(
+            request,
+            descriptors=descriptor.action_descriptors,
+            page_key=descriptor.key,
+            route_name=descriptor.route_name,
+            page_states=page_states,
+            data_facts=data_facts,
+            allowed_action_payloads=allowed_action_payloads,
+            workflow_entries=workflow_entries,
+        ),
+    }
+
+
+def resolve_operation_cards(
+    request: HttpRequest,
+    *,
+    descriptors: Iterable[ActionDescriptor] = (),
+    page_key: str | None = None,
+    route_name: str | None = None,
+    page_states: Iterable[str] | None = None,
+    data_facts: Mapping[str, Any] | None = None,
+    allowed_action_payloads: Iterable[Mapping[str, Any]] | None = None,
     workflow_entries: Mapping[str, WorkflowEntry] | None = None,
 ) -> list[dict[str, Any]]:
     context = build_resolution_context(
         request,
         page_key=page_key,
         route_name=route_name,
+        page_states=page_states,
+        data_facts=data_facts,
     )
     effective_workflow_entries = workflow_entries or resolve_workflow_entries(
         request,
         page_key=page_key,
         route_name=route_name,
     )
-    items: list[dict[str, Any]] = []
-    for descriptor in descriptors:
+    items: list[tuple[tuple[int, int], dict[str, Any]]] = []
+    for index, descriptor in enumerate(descriptors):
         if descriptor.permission_gate is not None and not descriptor.permission_gate(
             context
+        ):
+            continue
+        if descriptor.data_gate is not None and not descriptor.data_gate(context):
+            continue
+        if not _matches_required_states(
+            descriptor.required_states, context.page_states
         ):
             continue
         href = _resolve_descriptor_href(
@@ -702,21 +786,38 @@ def resolve_action_descriptors(
         if href is None:
             continue
         items.append(
-            {
-                "key": descriptor.key,
-                "title": descriptor.title,
-                "description": descriptor.description,
-                "icon": descriptor.icon,
-                "href": href,
-                "enabled": (
-                    True
-                    if descriptor.enabled_gate is None
-                    else descriptor.enabled_gate(context)
-                ),
-                "status": descriptor.status,
-            }
+            (
+                _operation_card_sort_key(descriptor.sequence, index),
+                {
+                    "key": descriptor.key,
+                    "title": descriptor.title,
+                    "description": descriptor.description,
+                    "icon": descriptor.icon,
+                    "href": href,
+                    "resolved_url": href,
+                    "enabled": (
+                        True
+                        if descriptor.enabled_gate is None
+                        else descriptor.enabled_gate(context)
+                    ),
+                    "status": descriptor.status,
+                    "sequence": descriptor.sequence,
+                    "primary_action": descriptor.primary_action,
+                    "workflow_key": descriptor.workflow_key,
+                    "route_name": descriptor.route_name,
+                },
+            )
         )
-    return items
+    for index, payload in enumerate(allowed_action_payloads or ()):  # pragma: no branch
+        normalized = _normalize_allowed_action_payload(
+            payload,
+            workflow_entries=effective_workflow_entries,
+            fallback_index=index + len(items),
+        )
+        if normalized is None:
+            continue
+        items.append(normalized)
+    return [item for _, item in sorted(items, key=lambda entry: entry[0])]
 
 
 def _resolve_descriptor_href(
@@ -737,3 +838,56 @@ def _reverse_route(route_name: str) -> str | None:
         return reverse(route_name)
     except NoReverseMatch:
         return None
+
+
+def _matches_required_states(
+    required_states: tuple[str, ...], page_states: frozenset[str]
+) -> bool:
+    if not required_states:
+        return True
+    return bool(page_states.intersection(required_states))
+
+
+def _operation_card_sort_key(
+    sequence: int | None, fallback_index: int
+) -> tuple[int, int]:
+    if sequence is None:
+        return (1, fallback_index)
+    return (0, sequence)
+
+
+def _normalize_allowed_action_payload(
+    payload: Mapping[str, Any],
+    *,
+    workflow_entries: Mapping[str, WorkflowEntry],
+    fallback_index: int,
+) -> tuple[tuple[int, int], dict[str, Any]] | None:
+    route_name = payload.get("route_name")
+    workflow_key = payload.get("workflow_key")
+    resolved_url = payload.get("resolved_url") or payload.get("href")
+    if route_name and workflow_key:
+        raise ValueError(
+            "operation action payloads must define at most one of route_name or workflow_key"
+        )
+    if resolved_url is None:
+        resolved_url = _resolve_descriptor_href(
+            route_name, workflow_key, workflow_entries
+        )
+    if not resolved_url:
+        return None
+    sequence = payload.get("sequence")
+    item = {
+        "key": str(payload.get("key") or payload.get("id") or fallback_index),
+        "title": str(payload.get("title") or payload.get("label") or "Action"),
+        "description": str(payload.get("description") or ""),
+        "icon": str(payload.get("icon") or "play_arrow"),
+        "href": resolved_url,
+        "resolved_url": resolved_url,
+        "enabled": bool(payload.get("enabled", True)),
+        "status": payload.get("status"),
+        "sequence": sequence,
+        "primary_action": bool(payload.get("primary_action", False)),
+        "workflow_key": workflow_key,
+        "route_name": route_name,
+    }
+    return (_operation_card_sort_key(sequence, fallback_index), item)

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -7298,6 +7298,8 @@ def _ui_operations_dashboard_payload(request) -> dict[str, Any]:
     dashboard_links = resolve_action_descriptors(
         request,
         descriptors=OPERATIONS_DASHBOARD_ACTION_DESCRIPTORS,
+        page_key="dashboard",
+        route_name="ui_operations_dashboard_page",
     )
     return {
         "project_id": project_id,

--- a/src/lims/views.py
+++ b/src/lims/views.py
@@ -263,6 +263,8 @@ def _dashboard_payload(request) -> dict[str, object]:
     dashboard_links = resolve_action_descriptors(
         request,
         descriptors=LIMS_DASHBOARD_ACTION_DESCRIPTORS,
+        page_key="lims-dashboard",
+        route_name="lims_dashboard_page",
     )
     payload["launchpad"] = dashboard_links
     payload["card_links"] = {item["key"]: item for item in dashboard_links}

--- a/src/tests/test_shell_navigation.py
+++ b/src/tests/test_shell_navigation.py
@@ -5,9 +5,12 @@ from django.urls import reverse
 from core.navigation import (
     ActionDescriptor,
     NavigationDescriptor,
+    OperationPageDescriptor,
     WorkflowEntry,
     resolve_action_descriptors,
     resolve_navigation,
+    resolve_operation_cards,
+    resolve_operation_page,
 )
 
 
@@ -128,6 +131,14 @@ def test_action_descriptor_requires_exactly_one_target():
         )
 
 
+def test_operation_page_descriptor_requires_surface_binding():
+    with pytest.raises(ValueError):
+        OperationPageDescriptor(
+            key="receiving",
+            title="Receiving",
+        )
+
+
 def test_resolve_action_descriptors_supports_workflow_entries():
     request = RequestFactory().get("/")
     sample_accession_url = reverse("lims_reference_sample_accession_page")
@@ -164,8 +175,13 @@ def test_resolve_action_descriptors_supports_workflow_entries():
             "description": "Open the canonical workflow entry.",
             "icon": "conversion_path",
             "href": sample_accession_url,
+            "resolved_url": sample_accession_url,
             "enabled": True,
             "status": None,
+            "sequence": None,
+            "primary_action": False,
+            "workflow_key": "sample-accession",
+            "route_name": None,
         }
     ]
 
@@ -201,8 +217,13 @@ def test_resolve_action_descriptors_reports_enabled_state():
             "description": "This action is enabled.",
             "icon": "check",
             "href": user_portal_url,
+            "resolved_url": user_portal_url,
             "enabled": True,
             "status": None,
+            "sequence": None,
+            "primary_action": False,
+            "workflow_key": None,
+            "route_name": "user_portal_dashboard_page",
         },
         {
             "key": "disabled",
@@ -210,7 +231,159 @@ def test_resolve_action_descriptors_reports_enabled_state():
             "description": "This action is disabled.",
             "icon": "block",
             "href": user_portal_url,
+            "resolved_url": user_portal_url,
             "enabled": False,
             "status": None,
+            "sequence": None,
+            "primary_action": False,
+            "workflow_key": None,
+            "route_name": "user_portal_dashboard_page",
         },
     ]
+
+
+def test_resolve_operation_cards_orders_sequences_before_fallback_order():
+    request = RequestFactory().get("/")
+    user_portal_url = reverse("user_portal_dashboard_page")
+
+    cards = resolve_operation_cards(
+        request,
+        descriptors=(
+            ActionDescriptor(
+                key="fallback-first",
+                title="Fallback first",
+                description="First authored fallback.",
+                icon="looks_one",
+                route_name="user_portal_dashboard_page",
+            ),
+            ActionDescriptor(
+                key="sequenced-two",
+                title="Sequenced two",
+                description="Second by sequence.",
+                icon="filter_2",
+                route_name="user_portal_dashboard_page",
+                sequence=20,
+            ),
+            ActionDescriptor(
+                key="sequenced-one",
+                title="Sequenced one",
+                description="First by sequence.",
+                icon="filter_1",
+                route_name="user_portal_dashboard_page",
+                sequence=10,
+                primary_action=True,
+            ),
+            ActionDescriptor(
+                key="fallback-second",
+                title="Fallback second",
+                description="Second authored fallback.",
+                icon="looks_two",
+                route_name="user_portal_dashboard_page",
+            ),
+        ),
+    )
+
+    assert [card["key"] for card in cards] == [
+        "sequenced-one",
+        "sequenced-two",
+        "fallback-first",
+        "fallback-second",
+    ]
+    assert cards[0]["resolved_url"] == user_portal_url
+    assert cards[0]["primary_action"] is True
+
+
+def test_resolve_operation_cards_filters_by_required_state_and_data_gate():
+    request = RequestFactory().get("/")
+
+    cards = resolve_operation_cards(
+        request,
+        descriptors=(
+            ActionDescriptor(
+                key="open-only",
+                title="Open only",
+                description="Only visible while open.",
+                icon="draft",
+                route_name="user_portal_dashboard_page",
+                required_states=("open",),
+            ),
+            ActionDescriptor(
+                key="data-only",
+                title="Data only",
+                description="Only visible when data is available.",
+                icon="database",
+                route_name="user_portal_dashboard_page",
+                data_gate=lambda context: bool(context.data_facts.get("has_batches")),
+            ),
+        ),
+        page_states=("open",),
+        data_facts={"has_batches": False},
+    )
+
+    assert [card["key"] for card in cards] == ["open-only"]
+
+
+def test_resolve_operation_cards_supports_allowed_action_payloads():
+    request = RequestFactory().get("/")
+    sample_accession_url = reverse("lims_reference_sample_accession_page")
+
+    cards = resolve_operation_cards(
+        request,
+        allowed_action_payloads=(
+            {
+                "key": "missing-route",
+                "title": "Missing route",
+                "route_name": "does_not_exist",
+            },
+            {
+                "key": "workflow-card",
+                "title": "Workflow card",
+                "description": "Uses workflow resolution.",
+                "icon": "conversion_path",
+                "workflow_key": "sample-accession",
+                "sequence": 5,
+            },
+            {
+                "key": "resolved-card",
+                "title": "Resolved card",
+                "description": "Uses a direct resolved URL.",
+                "icon": "link",
+                "resolved_url": reverse("user_portal_dashboard_page"),
+            },
+        ),
+        workflow_entries={
+            "sample-accession": WorkflowEntry(
+                key="sample-accession",
+                href=sample_accession_url,
+            )
+        },
+    )
+
+    assert [card["key"] for card in cards] == ["workflow-card", "resolved-card"]
+    assert cards[0]["resolved_url"] == sample_accession_url
+
+
+def test_resolve_operation_page_uses_descriptor_identity_for_context():
+    request = RequestFactory().get("/")
+    operation_page = resolve_operation_page(
+        request,
+        descriptor=OperationPageDescriptor(
+            key="receiving-operations",
+            title="Receiving operations",
+            route_name="lims_receiving_page",
+            action_descriptors=(
+                ActionDescriptor(
+                    key="stateful-card",
+                    title="Stateful card",
+                    description="Only visible for queued state.",
+                    icon="hourglass_top",
+                    route_name="lims_receiving_single_page",
+                    required_states=("queued",),
+                ),
+            ),
+        ),
+        page_states=("queued",),
+    )
+
+    assert operation_page["key"] == "receiving-operations"
+    assert [card["key"] for card in operation_page["action_cards"]] == ["stateful-card"]

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,4 +1,8 @@
 # Task Tracking
 
-- Issue #132: extend the ontology-driven shell registry to resolve one real contextual action surface through canonical workflow entries.
-- Status: completed for the shell navigation registry, the LIMS reference, task inbox, metadata, receiving, storage launchpads, the remaining LIMS and operations dashboard quick links, the follow-on local route normalization for parent, clear, back, and task-detail links, the cleanup that removed the last page-route literal and switched route-sensitive navigation regressions to named-route expectations, the final Python-side normalization of task mutation URLs plus the canonical receiving adapter surface, the remaining LIMS and operations UI page-request tests that were still asserting against literal page paths, and the low-risk template cleanup that replaced static selector API endpoint literals with named API routes.
+- Issue #135: implement operation-page descriptor resolution and deterministic action filtering.
+- Plan:
+	- define the operation-page and action-card resolver contract in `src/core/navigation.py`
+	- route existing launchpad payloads through the shared resolver without expanding into rendering-only work
+	- add targeted resolver and launchpad regression tests
+	- run targeted validation for navigation and LIMS/operations UI payloads


### PR DESCRIPTION
# Pull Request

## Summary

Implements issue #135 by adding the server-side operation-page action resolver in `src/core/navigation.py` and keeping the existing launchpad consumers backward-compatible.

This PR adds `OperationPageDescriptor`, extends `ActionDescriptor` with deterministic sequencing plus page-state and data-availability filtering, adds `resolve_operation_cards(...)` and `resolve_operation_page(...)`, keeps `resolve_action_descriptors(...)` as a compatibility wrapper, and passes explicit page identity from the current LIMS and operations launchpads.

Out of scope in this PR: reusable card-grid rendering and the proving operation pages tracked by #136 and #137.

## Review unit

- [x] PR scope maps to exactly one execution issue / implementation slice.
- [x] PR is still small enough for one-pass review.
- [x] PR is draft if any acceptance criteria or validation notes are still incomplete.
- [x] Work was delivered on this branch/PR instead of by direct-to-`main` implementation.

## Spec Kit artifacts

- [x] Spec path recorded: `specs/012-ontology-driven-operation-pages/spec.md`
- [x] Plan path recorded: `specs/012-ontology-driven-operation-pages/plan.md`
- [x] Tasks path recorded: `specs/012-ontology-driven-operation-pages/tasks.md`
- [x] PR body refreshed from `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python .github/scripts/spec_kit_workflow.py pr-body specs/012-ontology-driven-operation-pages`.

## Issue contract

- [x] Linked execution issue: #135 `Implement operation-page descriptor resolution and deterministic action filtering`
- [x] Scope boundary for this PR is explicit and matches the issue deliverables.

## Commit contract

- [x] Branch name uses the repository's Git-safe Conventional Commit slug format.
- [x] Branch commits use Conventional Commit subjects.
- [x] Final integration path for this work is auto-squash after green checks.
- [x] No unrelated refactors, drive-by fixes, or broad rename-only churn are mixed into this PR.

## Handoff contract

- [x] Changed files and risk notes are captured in PR description.
- [x] Done/blocker state is explicit (no implicit “follow-up later” gaps).
- [x] Maintainers can see the primary files or behaviors to inspect first.

Changed files to inspect first:
- `src/core/navigation.py`
- `src/tests/test_shell_navigation.py`
- `src/core/views.py`
- `src/lims/views.py`
- `tasks/todo.md`

Risk notes:
- Existing templates still consume `href`; the resolver now also emits `resolved_url` so later operation-page work can adopt the richer contract without breaking current launchpads.
- State and data gates are implemented generically here, but the deeper proving-surface use of those inputs remains for follow-up issues.

## Documentation chunk

- [ ] This is not a docs-only PR.
- [ ] Chunk selected: not applicable; implementation PR.
- [ ] Roadmap and README links are updated together when new design docs are introduced.
- [ ] Acceptance criteria and non-goals are present in each newly added design doc.
- [ ] Cross-doc references are updated so the chunk is reviewable end-to-end in one pass.

## Validation

- [x] Ran tests/checks relevant to this change.
- [x] `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python .github/scripts/spec_kit_workflow.py validate specs/012-ontology-driven-operation-pages`
- [x] `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/pytest tests/test_shell_navigation.py`
- [x] `docker compose up -d postgres && cd src && /home/jmduda/KodeX.2026/mtafiti/.venv/bin/pytest tests/test_lims_ui.py tests/test_ui_operations_api.py`
- [x] `bash .github/scripts/local_fast_feedback.sh --full-gate`
