### PR TITLE
Issue 136: extract shared action-card grids

### DIFF
--- a/src/core/templates/core/ui/base_fallback.html
+++ b/src/core/templates/core/ui/base_fallback.html
@@ -182,6 +182,59 @@
       .panel-header { display: flex; align-items: start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
       .panel-title { margin: 0; font-size: 1.05rem; }
       .panel-description { margin: 4px 0 0; color: var(--color-text-muted); font-size: 14px; }
+      .action-card-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin: 0; }
+      .action-card-grid__item { min-width: 0; }
+      .action-card-grid__empty { grid-column: 1 / -1; }
+      .action-card {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 14px;
+        min-height: 100%;
+        color: inherit;
+        text-decoration: none;
+        transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+      }
+      .action-card:hover,
+      .action-card:focus-visible {
+        border-color: rgba(2, 132, 199, 0.32);
+        box-shadow: 0 14px 30px rgba(14, 73, 142, 0.12);
+        transform: translateY(-2px);
+      }
+      .action-card:focus-visible {
+        outline: 3px solid rgba(2, 132, 199, 0.28);
+        outline-offset: 2px;
+      }
+      .action-card--disabled {
+        color: var(--color-text-muted);
+        cursor: not-allowed;
+        border-style: dashed;
+        box-shadow: none;
+      }
+      .action-card__header {
+        display: flex;
+        align-items: start;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .action-card__copy { min-width: 0; }
+      .action-card__title { margin: 0; }
+      .action-card__description { margin-bottom: 0; }
+      .action-card__icon,
+      .action-card__chip { flex-shrink: 0; }
+      .action-card__footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-top: auto;
+        font-size: 14px;
+        font-weight: 700;
+      }
+      .action-card__action-label { color: var(--color-primary-strong); }
+      .action-card--disabled .action-card__action-label { color: var(--color-text-muted); }
+      .action-card__arrow { color: var(--color-primary-strong); }
+      .action-card--disabled .action-card__arrow { color: var(--color-text-muted); }
       .stat-card { padding: 18px; }
       .stat-card h3 { margin: 0 0 12px; font-size: 1rem; }
       .toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 14px; }

--- a/src/core/templates/core/ui/includes/action_card.html
+++ b/src/core/templates/core/ui/includes/action_card.html
@@ -1,0 +1,45 @@
+{% with resolved_url=item.resolved_url|default:item.href is_enabled=item.enabled|default:True %}
+{% if is_enabled and resolved_url %}
+<a href="{{ resolved_url }}"
+   class="card action-card"
+   data-action-card="{{ item.key }}"
+   {% if action_namespace == "lims" %}data-lims-action="{{ item.key }}"{% endif %}
+   aria-label="{{ item.title }}">
+  <div class="action-card__header">
+    <div class="action-card__copy">
+      <h2 class="panel-title action-card__title">{{ item.title }}</h2>
+      <p class="panel-description action-card__description">{{ item.description }}</p>
+    </div>
+    {% if show_state_chip %}
+    <span class="utility-chip action-card__chip">{{ is_enabled|yesno:"ready,restricted" }}</span>
+    {% elif item.icon %}
+    <span class="nav-icon material-symbols-outlined action-card__icon" aria-hidden="true">{{ item.icon }}</span>
+    {% endif %}
+  </div>
+  <div class="action-card__footer">
+    <span class="action-card__action-label">{{ action_label|default:"Open" }} {{ item.title|lower }}</span>
+    <span class="material-symbols-outlined action-card__arrow" aria-hidden="true">arrow_forward</span>
+  </div>
+</a>
+{% else %}
+<div class="card action-card action-card--disabled"
+     data-action-card="{{ item.key }}"
+     {% if action_namespace == "lims" %}data-lims-action="{{ item.key }}"{% endif %}
+     aria-disabled="true"
+     tabindex="0">
+  <div class="action-card__header">
+    <div class="action-card__copy">
+      <h2 class="panel-title action-card__title">{{ item.title }}</h2>
+      <p class="panel-description action-card__description">{{ item.description }}</p>
+    </div>
+    {% if item.icon %}
+    <span class="nav-icon material-symbols-outlined action-card__icon" aria-hidden="true">{{ item.icon }}</span>
+    {% endif %}
+  </div>
+  <div class="action-card__footer">
+    <span class="action-card__action-label">{{ disabled_label|default:"Unavailable for current role" }}</span>
+    <span class="utility-chip action-card__chip">restricted</span>
+  </div>
+</div>
+{% endif %}
+{% endwith %}

--- a/src/core/templates/core/ui/includes/action_card_grid.html
+++ b/src/core/templates/core/ui/includes/action_card_grid.html
@@ -1,0 +1,11 @@
+<div class="row action-card-grid" role="list">
+  {% for item in items %}
+  <div class="col s12 m6 l4 action-card-grid__item" role="listitem">
+    {% include "core/ui/includes/action_card.html" with item=item action_namespace=action_namespace show_state_chip=show_state_chip action_label=action_label disabled_label=disabled_label %}
+  </div>
+  {% empty %}
+  <div class="action-card-grid__empty">
+    {% include "core/ui/includes/empty_state.html" with empty_icon=empty_icon|default:"dashboard_customize" empty_title=empty_title|default:"No actions available" empty_description=empty_description|default:"No operational actions are currently available for this page." %}
+  </div>
+  {% endfor %}
+</div>

--- a/src/core/templates/core/ui/user_base.html
+++ b/src/core/templates/core/ui/user_base.html
@@ -180,6 +180,59 @@
       .panel-header { display: flex; align-items: start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
       .panel-title { margin: 0; font-size: 1.05rem; }
       .panel-description { margin: 4px 0 0; color: var(--color-text-muted); font-size: 14px; }
+      .action-card-grid { display: grid; gap: 14px; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin: 0; }
+      .action-card-grid__item { min-width: 0; }
+      .action-card-grid__empty { grid-column: 1 / -1; }
+      .action-card {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        gap: 14px;
+        min-height: 100%;
+        color: inherit;
+        text-decoration: none;
+        transition: transform .18s ease, box-shadow .18s ease, border-color .18s ease;
+      }
+      .action-card:hover,
+      .action-card:focus-visible {
+        border-color: rgba(2, 132, 199, 0.32);
+        box-shadow: 0 14px 30px rgba(14, 73, 142, 0.12);
+        transform: translateY(-2px);
+      }
+      .action-card:focus-visible {
+        outline: 3px solid rgba(2, 132, 199, 0.28);
+        outline-offset: 2px;
+      }
+      .action-card--disabled {
+        color: var(--color-text-muted);
+        cursor: not-allowed;
+        border-style: dashed;
+        box-shadow: none;
+      }
+      .action-card__header {
+        display: flex;
+        align-items: start;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .action-card__copy { min-width: 0; }
+      .action-card__title { margin: 0; }
+      .action-card__description { margin-bottom: 0; }
+      .action-card__icon,
+      .action-card__chip { flex-shrink: 0; }
+      .action-card__footer {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        margin-top: auto;
+        font-size: 14px;
+        font-weight: 700;
+      }
+      .action-card__action-label { color: var(--color-primary-strong); }
+      .action-card--disabled .action-card__action-label { color: var(--color-text-muted); }
+      .action-card__arrow { color: var(--color-primary-strong); }
+      .action-card--disabled .action-card__arrow { color: var(--color-text-muted); }
       .actions { display: flex; flex-wrap: wrap; gap: 8px; }
       .section-stack { display: grid; gap: 14px; }
       .field-grid { display: grid; gap: 10px; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }

--- a/src/lims/templates/lims/dashboard.html
+++ b/src/lims/templates/lims/dashboard.html
@@ -16,20 +16,7 @@
 
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="LIMS launchpad" panel_description="Move across the major operational areas without dropping back to raw JSON APIs." %}
-  <div class="cards">
-    {% for item in payload.launchpad %}
-    <article class="card">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">{{ item.title }}</h2>
-          <p class="panel-description">{{ item.description }}</p>
-        </div>
-        <span class="utility-chip">{{ item.enabled|yesno:"ready,restricted" }}</span>
-      </div>
-      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
-    </article>
-    {% endfor %}
-  </div>
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.launchpad action_namespace="lims" show_state_chip=True empty_title="No launchpad actions available" empty_description="No LIMS launchpad actions are currently available for this workspace." %}
 </section>
 
 <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">

--- a/src/lims/templates/lims/metadata.html
+++ b/src/lims/templates/lims/metadata.html
@@ -22,20 +22,7 @@
 {% if payload.capabilities.can_manage_metadata %}
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a metadata workflow" panel_description="Keep the launchpad focused on navigation and review; complete each metadata action on its own page." %}
-  <div class="cards">
-    {% for item in payload.actions %}
-    <article class="card">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">{{ item.title }}</h2>
-          <p class="panel-description">{{ item.description }}</p>
-        </div>
-        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
-      </div>
-      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
-    </article>
-    {% endfor %}
-  </div>
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No metadata workflows available" empty_description="No metadata workflows are currently available for your role." %}
 </section>
 {% endif %}
 

--- a/src/lims/templates/lims/receiving.html
+++ b/src/lims/templates/lims/receiving.html
@@ -13,20 +13,7 @@
 
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a receiving workflow" panel_description="Operator input starts from a dedicated page per task, rather than a mixed multi-form dashboard." %}
-  <div class="cards">
-    {% for item in payload.actions %}
-    <article class="card">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">{{ item.title }}</h2>
-          <p class="panel-description">{{ item.description }}</p>
-        </div>
-        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
-      </div>
-      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
-    </article>
-    {% endfor %}
-  </div>
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No receiving workflows available" empty_description="No receiving workflows are currently available for your role." %}
 </section>
 
 <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">

--- a/src/lims/templates/lims/reference.html
+++ b/src/lims/templates/lims/reference.html
@@ -15,20 +15,7 @@
 {% if payload.capabilities.can_manage_reference %}
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a reference workflow" panel_description="Keep the launchpad focused on navigation and status; complete each setup action on its own page." %}
-  <div class="cards">
-    {% for item in payload.actions %}
-    <article class="card">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">{{ item.title }}</h2>
-          <p class="panel-description">{{ item.description }}</p>
-        </div>
-        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
-      </div>
-      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
-    </article>
-    {% endfor %}
-  </div>
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No reference workflows available" empty_description="No reference workflows are currently available for your role." %}
 </section>
 {% endif %}
 

--- a/src/lims/templates/lims/storage_inventory.html
+++ b/src/lims/templates/lims/storage_inventory.html
@@ -13,24 +13,7 @@
 
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a storage or inventory workflow" panel_description="Administration stays split into focused pages so hierarchy, placement, catalog, lot, and ledger actions are not mixed together." %}
-  <div class="cards">
-    {% for item in payload.actions %}
-    {% if item.enabled %}
-    <article class="card">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">{{ item.title }}</h2>
-          <p class="panel-description">{{ item.description }}</p>
-        </div>
-        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
-      </div>
-      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
-    </article>
-    {% endif %}
-    {% empty %}
-    <article class="card"><p>No storage or inventory admin actions are available for your current role.</p></article>
-    {% endfor %}
-  </div>
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No storage or inventory actions available" empty_description="No storage or inventory administration actions are currently available for this role." %}
 </section>
 
 <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">

--- a/src/lims/templates/lims/task_inbox.html
+++ b/src/lims/templates/lims/task_inbox.html
@@ -13,20 +13,7 @@
 
 <section class="panel" data-lims-action="task-inbox">
   {% include "core/ui/includes/panel_header.html" with panel_title="Task inbox workflows" panel_description="Use the inbox as the main follow-up surface, while transitional receiving pages remain available for task entry when a node advertises an adapter surface." %}
-  <div class="cards">
-    {% for item in payload.actions %}
-    <article class="card">
-      <div class="panel-header">
-        <div>
-          <h2 class="panel-title">{{ item.title }}</h2>
-          <p class="panel-description">{{ item.description }}</p>
-        </div>
-        <span class="nav-icon material-symbols-outlined" aria-hidden="true">{{ item.icon }}</span>
-      </div>
-      <p><a href="{{ item.href }}">Open {{ item.title|lower }} →</a></p>
-    </article>
-    {% endfor %}
-  </div>
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No task inbox workflows available" empty_description="No task inbox workflows are currently available for your role." %}
 </section>
 
 <section class="panel">

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -374,6 +374,50 @@ def test_lims_launchpads_render_canonical_action_links():
 
 
 @pytest.mark.django_db(transaction=True)
+def test_lims_launchpads_use_shared_action_card_grid_markup():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-action-card-grid")
+
+    reference = client.get(
+        reverse("lims_reference_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    metadata = client.get(
+        reverse("lims_metadata_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    task_inbox = client.get(
+        reverse("lims_task_inbox_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    receiving = client.get(
+        reverse("lims_receiving_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    storage = client.get(
+        reverse("lims_storage_inventory_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    for response in (reference, metadata, task_inbox, receiving, storage):
+        assert response.status_code == 200
+        assert b"action-card-grid" in response.content
+        assert b'class="card action-card' in response.content
+
+    assert b'data-action-card="reference-create-lab"' in reference.content
+    assert b'data-lims-action="reference-create-lab"' in reference.content
+    assert b'data-action-card="metadata-create-vocabulary"' in metadata.content
+    assert b'data-action-card="task-open-receiving"' in task_inbox.content
+    assert b'data-action-card="receiving-single"' in receiving.content
+    assert b'data-action-card="storage-create-location"' in storage.content
+
+
+@pytest.mark.django_db(transaction=True)
 def test_lims_dashboard_renders_canonical_quick_links():
     client = Client()
     host = _create_lims_host(client, "tenant-ui-dashboard-links")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,8 @@
 # Task Tracking
 
-- Issue #135: implement operation-page descriptor resolution and deterministic action filtering.
+- Issue #136: implement the reusable action-card component and bounded card-grid rendering contract.
 - Plan:
-	- define the operation-page and action-card resolver contract in `src/core/navigation.py`
-	- route existing launchpad payloads through the shared resolver without expanding into rendering-only work
-	- add targeted resolver and launchpad regression tests
-	- run targeted validation for navigation and LIMS/operations UI payloads
+	- extract a shared action-card partial and bounded grid wrapper under `src/core/templates/core/ui/includes/`
+	- convert the repeated LIMS launchpad card markup to the shared includes without reopening resolver logic
+	- add rendering-focused regression coverage for grid and action-card markers in `src/tests/test_lims_ui.py`
+	- run targeted UI tests and the full merge gate


### PR DESCRIPTION
# Pull Request

## Summary

Implements issue #136 by extracting a reusable action-card partial and bounded card-grid wrapper for operational launchpads, then converting the existing LIMS launchpad pages to the shared rendering contract.

This PR adds shared includes for full-card click behavior and empty-state handling, adds the shared action-card CSS hooks to the existing shell bases, and removes duplicated launchpad markup from the current LIMS dashboard, reference, metadata, task inbox, receiving, and storage pages.

Out of scope in this PR: descriptor-resolution logic from #135 and the proving operation pages plus FAB derivation tracked by #137.

## Review unit

- [x] PR scope maps to exactly one execution issue / implementation slice.
- [x] PR is still small enough for one-pass review.
- [x] PR is draft if any acceptance criteria or validation notes are still incomplete.
- [x] Work was delivered on this branch/PR instead of by direct-to-`main` implementation.

## Spec Kit artifacts

- [x] Spec path recorded: `specs/012-ontology-driven-operation-pages/spec.md`
- [x] Plan path recorded: `specs/012-ontology-driven-operation-pages/plan.md`
- [x] Tasks path recorded: `specs/012-ontology-driven-operation-pages/tasks.md`
- [x] PR body refreshed from `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python .github/scripts/spec_kit_workflow.py pr-body specs/012-ontology-driven-operation-pages`.

## Issue contract

- [x] Linked execution issue: #136 `Implement reusable action-card component and bounded card-grid rendering`
- [x] Scope boundary for this PR is explicit and matches the issue deliverables.

## Commit contract

- [x] Branch name uses the repository's Git-safe Conventional Commit slug format.
- [x] Branch commits use Conventional Commit subjects.
- [x] Final integration path for this work is auto-squash after green checks.
- [x] No unrelated refactors, drive-by fixes, or broad rename-only churn are mixed into this PR.

## Handoff contract

- [x] Changed files and risk notes are captured in PR description.
- [x] Done/blocker state is explicit (no implicit “follow-up later” gaps).
- [x] Maintainers can see the primary files or behaviors to inspect first.

Changed files to inspect first:
- `src/core/templates/core/ui/includes/action_card.html`
- `src/core/templates/core/ui/includes/action_card_grid.html`
- `src/core/templates/core/ui/base_fallback.html`
- `src/core/templates/core/ui/user_base.html`
- `src/tests/test_lims_ui.py`

Risk notes:
- The shared action-card component now emits both `data-action-card` and `data-lims-action` markers for LIMS launchpads; page-specific tests should continue to use the existing LIMS markers where appropriate.
- Storage launchpad cards now reuse the common rendering path rather than a page-local enabled-only fork, so disabled cards render consistently as restricted cards.

## Documentation chunk

- [ ] This is not a docs-only PR.
- [ ] Chunk selected: not applicable; implementation PR.
- [ ] Roadmap and README links are updated together when new design docs are introduced.
- [ ] Acceptance criteria and non-goals are present in each newly added design doc.
- [ ] Cross-doc references are updated so the chunk is reviewable end-to-end in one pass.

## Validation

- [x] Ran tests/checks relevant to this change.
- [x] `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python .github/scripts/spec_kit_workflow.py validate specs/012-ontology-driven-operation-pages`
- [x] `docker compose up -d postgres && cd src && /home/jmduda/KodeX.2026/mtafiti/.venv/bin/pytest tests/test_lims_ui.py`
- [x] `bash .github/scripts/local_fast_feedback.sh --full-gate`
