### PR TITLE
Issue 137: prove operation pages and FAB derivation

### DIFF
--- a/src/core/navigation.py
+++ b/src/core/navigation.py
@@ -85,6 +85,7 @@ class OperationPageDescriptor:
     route_name: str | None = None
     navigation_key: str | None = None
     action_descriptors: tuple[ActionDescriptor, ...] = ()
+    fab_enabled: bool = False
 
     def __post_init__(self) -> None:
         if not self.route_name and not self.navigation_key:
@@ -260,6 +261,7 @@ REFERENCE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Register one tenant lab at a time using a dedicated lab form.",
         icon="add_business",
         route_name="lims_reference_create_lab_page",
+        sequence=10,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.reference.manage"
         ),
@@ -270,6 +272,7 @@ REFERENCE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Create one study and optionally attach its lead lab.",
         icon="schema",
         route_name="lims_reference_create_study_page",
+        sequence=20,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.reference.manage"
         ),
@@ -280,6 +283,7 @@ REFERENCE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Register one field or collection site and link it to study and lab selectors.",
         icon="location_city",
         route_name="lims_reference_create_site_page",
+        sequence=30,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.reference.manage"
         ),
@@ -290,6 +294,7 @@ REFERENCE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Start the Tanzania-backed geography import from a single sync action page.",
         icon="sync",
         route_name="lims_reference_address_sync_page",
+        sequence=40,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.reference.manage"
         ),
@@ -300,10 +305,20 @@ REFERENCE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Provision and inspect the canonical sample accession reference bundle used by the receiving adapters.",
         icon="conversion_path",
         workflow_key="sample-accession-reference",
+        sequence=50,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.reference.manage"
         ),
     ),
+)
+
+
+REFERENCE_OPERATION_PAGE_DESCRIPTOR = OperationPageDescriptor(
+    key="lims-reference",
+    title="Reference and geography",
+    route_name="lims_reference_page",
+    navigation_key="lims-reference",
+    action_descriptors=REFERENCE_ACTION_DESCRIPTORS,
 )
 
 
@@ -382,6 +397,8 @@ RECEIVING_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Capture intake metadata, record a QC accept/reject decision, then log storage or rejection details.",
         icon="move_to_inbox",
         route_name="lims_receiving_single_page",
+        sequence=10,
+        primary_action=True,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.artifact.view"
         ),
@@ -392,6 +409,7 @@ RECEIVING_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Download an Excel-friendly CSV template, complete receipt/QC/storage columns, and import the batch.",
         icon="upload_file",
         route_name="lims_receiving_batch_page",
+        sequence=20,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.artifact.view"
         ),
@@ -402,10 +420,21 @@ RECEIVING_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Specify the lab form, expected sample, and external ID, then process the imported record through QC.",
         icon="cloud_download",
         route_name="lims_receiving_edc_import_page",
+        sequence=30,
         permission_gate=lambda context: has_lims_permission_in_context(
             context, "lims.artifact.view"
         ),
     ),
+)
+
+
+RECEIVING_OPERATION_PAGE_DESCRIPTOR = OperationPageDescriptor(
+    key="lims-receiving",
+    title="Receiving and accessioning",
+    route_name="lims_receiving_page",
+    navigation_key="lims-receiving",
+    action_descriptors=RECEIVING_ACTION_DESCRIPTORS,
+    fab_enabled=True,
 )
 
 
@@ -416,6 +445,7 @@ STORAGE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Build the storage hierarchy one node at a time so facilities, equipment, containers, and positions stay valid.",
         icon="add_home_work",
         route_name="lims_storage_create_location_page",
+        sequence=10,
         enabled_gate=lambda context: has_lims_permission_in_context(
             context, "lims.storage.manage"
         ),
@@ -426,6 +456,11 @@ STORAGE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Log a biospecimen or pool placement event against the immutable storage history ledger.",
         icon="move_item",
         route_name="lims_storage_create_placement_page",
+        sequence=20,
+        required_states=("has-storage-locations",),
+        data_gate=lambda context: bool(
+            context.data_facts.get("has_placeable_artifacts")
+        ),
         enabled_gate=lambda context: has_lims_permission_in_context(
             context, "lims.storage.manage"
         ),
@@ -436,6 +471,7 @@ STORAGE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Register consumables, kits, reagents, labels, and other reusable catalog entries.",
         icon="inventory_2",
         route_name="lims_storage_create_material_page",
+        sequence=30,
         enabled_gate=lambda context: has_lims_permission_in_context(
             context, "lims.inventory.manage"
         ),
@@ -446,6 +482,8 @@ STORAGE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Capture lot receipt, storage, expiry, and opening stock in one dedicated lot form.",
         icon="local_shipping",
         route_name="lims_storage_create_lot_page",
+        sequence=40,
+        required_states=("has-inventory-materials",),
         enabled_gate=lambda context: has_lims_permission_in_context(
             context, "lims.inventory.manage"
         ),
@@ -456,10 +494,22 @@ STORAGE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
         description="Post adjustments, reservations, releases, transfers, consumptions, and disposals to the lot ledger.",
         icon="sync_alt",
         route_name="lims_storage_create_transaction_page",
+        sequence=50,
+        required_states=("has-active-lots",),
         enabled_gate=lambda context: has_lims_permission_in_context(
             context, "lims.inventory.manage"
         ),
     ),
+)
+
+
+STORAGE_OPERATION_PAGE_DESCRIPTOR = OperationPageDescriptor(
+    key="lims-storage",
+    title="Storage and inventory administration",
+    route_name="lims_storage_inventory_page",
+    navigation_key="lims-storage",
+    action_descriptors=STORAGE_ACTION_DESCRIPTORS,
+    fab_enabled=True,
 )
 
 
@@ -725,21 +775,54 @@ def resolve_operation_page(
     allowed_action_payloads: Iterable[Mapping[str, Any]] | None = None,
     workflow_entries: Mapping[str, WorkflowEntry] | None = None,
 ) -> dict[str, Any]:
+    action_cards = resolve_operation_cards(
+        request,
+        descriptors=descriptor.action_descriptors,
+        page_key=descriptor.key,
+        route_name=descriptor.route_name,
+        page_states=page_states,
+        data_facts=data_facts,
+        allowed_action_payloads=allowed_action_payloads,
+        workflow_entries=workflow_entries,
+    )
     return {
         "key": descriptor.key,
         "title": descriptor.title,
         "route_name": descriptor.route_name,
         "navigation_key": descriptor.navigation_key,
-        "action_cards": resolve_operation_cards(
-            request,
-            descriptors=descriptor.action_descriptors,
-            page_key=descriptor.key,
-            route_name=descriptor.route_name,
-            page_states=page_states,
-            data_facts=data_facts,
-            allowed_action_payloads=allowed_action_payloads,
-            workflow_entries=workflow_entries,
+        "action_cards": action_cards,
+        "floating_action": derive_operation_fab(
+            action_cards,
+            enabled=descriptor.fab_enabled,
         ),
+    }
+
+
+def derive_operation_fab(
+    action_cards: Iterable[Mapping[str, Any]], *, enabled: bool
+) -> dict[str, Any] | None:
+    if not enabled:
+        return None
+    allowed_cards = [
+        card
+        for card in action_cards
+        if card.get("enabled", True) and (card.get("resolved_url") or card.get("href"))
+    ]
+    if not allowed_cards:
+        return None
+    primary_card = next(
+        (card for card in allowed_cards if card.get("primary_action")),
+        allowed_cards[0],
+    )
+    href = primary_card.get("resolved_url") or primary_card.get("href")
+    if not href:
+        return None
+    return {
+        "key": primary_card["key"],
+        "title": primary_card["title"],
+        "icon": primary_card.get("icon") or "arrow_forward",
+        "href": href,
+        "resolved_url": href,
     }
 
 

--- a/src/core/templates/core/ui/includes/floating_action_button.html
+++ b/src/core/templates/core/ui/includes/floating_action_button.html
@@ -1,0 +1,11 @@
+{% if item and item.resolved_url|default:item.href %}
+<a class="button fab"
+   href="{{ item.resolved_url|default:item.href }}"
+   aria-label="{{ item.title }}"
+   title="{{ item.title }}"
+   data-tooltip="{{ item.title }}"
+   data-floating-action="{{ item.key }}">
+  <span class="fab-icon material-symbols-outlined" aria-hidden="true">{{ item.icon|default:"arrow_forward" }}</span>
+  <span class="fab-label">{{ item.title }}</span>
+</a>
+{% endif %}

--- a/src/lims/templates/lims/receiving.html
+++ b/src/lims/templates/lims/receiving.html
@@ -13,7 +13,7 @@
 
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a receiving workflow" panel_description="Operator input starts from a dedicated page per task, rather than a mixed multi-form dashboard." %}
-  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No receiving workflows available" empty_description="No receiving workflows are currently available for your role." %}
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.operation_page.action_cards action_namespace="lims" empty_title="No receiving workflows available" empty_description="No receiving workflows are currently available for your role." %}
 </section>
 
 <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
@@ -31,4 +31,8 @@
   {% include "core/ui/includes/panel_header.html" with panel_title="Discrepancies" panel_description="Current discrepancy log raised during receiving." %}
   <div class="table-wrap"><table><thead><tr><th>Code</th><th>Status</th><th>Recorded by</th><th>Notes</th></tr></thead><tbody>{% for item in payload.discrepancies %}<tr><td>{{ item.code }}</td><td>{{ item.status }}</td><td>{{ item.recorded_by|default:"-" }}</td><td>{{ item.notes|default:"-" }}</td></tr>{% empty %}<tr><td colspan="4">No discrepancies yet.</td></tr>{% endfor %}</tbody></table></div>
 </section>
+{% endblock %}
+
+{% block floating_action %}
+  {% include "core/ui/includes/floating_action_button.html" with item=payload.operation_page.floating_action %}
 {% endblock %}

--- a/src/lims/templates/lims/reference.html
+++ b/src/lims/templates/lims/reference.html
@@ -15,7 +15,7 @@
 {% if payload.capabilities.can_manage_reference %}
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a reference workflow" panel_description="Keep the launchpad focused on navigation and status; complete each setup action on its own page." %}
-  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No reference workflows available" empty_description="No reference workflows are currently available for your role." %}
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.operation_page.action_cards action_namespace="lims" empty_title="No reference workflows available" empty_description="No reference workflows are currently available for your role." %}
 </section>
 {% endif %}
 

--- a/src/lims/templates/lims/storage_inventory.html
+++ b/src/lims/templates/lims/storage_inventory.html
@@ -13,7 +13,7 @@
 
 <section class="panel">
   {% include "core/ui/includes/panel_header.html" with panel_title="Choose a storage or inventory workflow" panel_description="Administration stays split into focused pages so hierarchy, placement, catalog, lot, and ledger actions are not mixed together." %}
-  {% include "core/ui/includes/action_card_grid.html" with items=payload.actions action_namespace="lims" empty_title="No storage or inventory actions available" empty_description="No storage or inventory administration actions are currently available for this role." %}
+  {% include "core/ui/includes/action_card_grid.html" with items=payload.operation_page.action_cards action_namespace="lims" empty_title="No storage or inventory actions available" empty_description="No storage or inventory administration actions are currently available for this role." %}
 </section>
 
 <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
@@ -105,4 +105,8 @@
     </div>
   </section>
 </div>
+{% endblock %}
+
+{% block floating_action %}
+  {% include "core/ui/includes/floating_action_button.html" with item=payload.operation_page.floating_action %}
 {% endblock %}

--- a/src/lims/views.py
+++ b/src/lims/views.py
@@ -17,13 +17,14 @@ from core.models import CollaborationDocument, CollaborationDocumentVersion
 from core.navigation import (
     LIMS_DASHBOARD_ACTION_DESCRIPTORS,
     METADATA_ACTION_DESCRIPTORS,
-    RECEIVING_ACTION_DESCRIPTORS,
-    REFERENCE_ACTION_DESCRIPTORS,
-    STORAGE_ACTION_DESCRIPTORS,
+    RECEIVING_OPERATION_PAGE_DESCRIPTOR,
+    REFERENCE_OPERATION_PAGE_DESCRIPTOR,
+    STORAGE_OPERATION_PAGE_DESCRIPTOR,
     TASK_INBOX_ACTION_DESCRIPTORS,
     WORKSPACE_NAVIGATION_DESCRIPTORS,
     resolve_action_descriptors,
     resolve_navigation,
+    resolve_operation_page,
 )
 from core.ui_shell import resolve_ui_base_template
 
@@ -576,12 +577,11 @@ def _reference_launchpad_payload(request) -> dict[str, object]:
         sync_run_to_dict(item)
         for item in TanzaniaAddressSyncRun.objects.order_by("-created_at")[:5]
     ]
-    payload["actions"] = resolve_action_descriptors(
+    payload["operation_page"] = resolve_operation_page(
         request,
-        descriptors=REFERENCE_ACTION_DESCRIPTORS,
-        page_key="lims-reference",
-        route_name="lims_reference_page",
+        descriptor=REFERENCE_OPERATION_PAGE_DESCRIPTOR,
     )
+    payload["actions"] = payload["operation_page"]["action_cards"]
     return payload
 
 
@@ -1020,12 +1020,11 @@ def _receiving_launchpad_payload(request) -> dict[str, object]:
         _receiving_discrepancy_to_dict(item)
         for item in ReceivingDiscrepancy.objects.order_by("-created_at")[:8]
     ]
-    payload["actions"] = resolve_action_descriptors(
+    payload["operation_page"] = resolve_operation_page(
         request,
-        descriptors=RECEIVING_ACTION_DESCRIPTORS,
-        page_key="lims-receiving",
-        route_name="lims_receiving_page",
+        descriptor=RECEIVING_OPERATION_PAGE_DESCRIPTOR,
     )
+    payload["actions"] = payload["operation_page"]["action_cards"]
     return payload
 
 
@@ -1183,11 +1182,14 @@ def _storage_inventory_page_payload(request) -> dict[str, object]:
         summary="Choose a focused storage or inventory administration task, then complete it from a dedicated page.",
         kicker="Storage operations",
     )
+    locations_count = StorageLocation.objects.count()
+    materials_count = InventoryMaterial.objects.count()
+    active_lots_count = InventoryLot.objects.filter(is_active=True).count()
     payload["cards"] = {
-        "locations": StorageLocation.objects.count(),
+        "locations": locations_count,
         "storage_records": BiospecimenStorageRecord.objects.count(),
-        "materials": InventoryMaterial.objects.count(),
-        "active_lots": InventoryLot.objects.filter(is_active=True).count(),
+        "materials": materials_count,
+        "active_lots": active_lots_count,
     }
     payload["locations"] = [
         _storage_location_to_dict(item)
@@ -1227,12 +1229,25 @@ def _storage_inventory_page_payload(request) -> dict[str, object]:
             "lot", "lot__material", "location"
         ).order_by("-created_at")[:8]
     ]
-    payload["actions"] = resolve_action_descriptors(
-        request,
-        descriptors=STORAGE_ACTION_DESCRIPTORS,
-        page_key="lims-storage",
-        route_name="lims_storage_inventory_page",
+    page_states = tuple(
+        state
+        for state, is_active in (
+            ("has-storage-locations", locations_count > 0),
+            ("has-inventory-materials", materials_count > 0),
+            ("has-active-lots", active_lots_count > 0),
+        )
+        if is_active
     )
+    payload["operation_page"] = resolve_operation_page(
+        request,
+        descriptor=STORAGE_OPERATION_PAGE_DESCRIPTOR,
+        page_states=page_states,
+        data_facts={
+            "has_placeable_artifacts": Biospecimen.objects.exists()
+            or BiospecimenPool.objects.exists(),
+        },
+    )
+    payload["actions"] = payload["operation_page"]["action_cards"]
     return payload
 
 

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -7,11 +7,16 @@ from django.urls import reverse
 from django_tenants.utils import schema_context
 
 from lims.models import (
+    Biospecimen,
+    BiospecimenType,
     Country,
     District,
+    InventoryLot,
+    InventoryMaterial,
     Lab,
     Region,
     Site,
+    StorageLocation,
     Street,
     Study,
     TanzaniaAddressSyncRun,
@@ -345,6 +350,35 @@ def test_lims_launchpads_render_canonical_action_links():
     storage_location_url = reverse("lims_storage_create_location_page")
     storage_transaction_url = reverse("lims_storage_create_transaction_page")
 
+    summary = client.get(
+        "/api/v1/lims/summary", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin"
+    )
+    schema_name = summary.json()["tenant_schema"]
+
+    with schema_context(schema_name):
+        lab = Lab.objects.create(name="Ops Storage Lab", code="ops-storage-lab")
+        location = StorageLocation.objects.create(
+            lab=lab,
+            name="Operations freezer",
+            code="operations-freezer",
+            level=StorageLocation.Level.FACILITY,
+        )
+        material = InventoryMaterial.objects.create(
+            name="Transport tube",
+            code="transport-tube",
+            category=InventoryMaterial.Category.CONSUMABLE,
+            default_unit="ea",
+        )
+        InventoryLot.objects.create(
+            material=material,
+            lab=lab,
+            storage_location=location,
+            lot_number="OPS-LOT-001",
+            initial_quantity=25,
+            on_hand_quantity=25,
+            unit_of_measure="ea",
+        )
+
     task_inbox = client.get(
         task_inbox_url, HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin"
     )
@@ -415,6 +449,111 @@ def test_lims_launchpads_use_shared_action_card_grid_markup():
     assert b'data-action-card="task-open-receiving"' in task_inbox.content
     assert b'data-action-card="receiving-single"' in receiving.content
     assert b'data-action-card="storage-create-location"' in storage.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_receiving_operation_page_derives_fab_from_primary_action():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-receiving-fab")
+    receiving_url = reverse("lims_receiving_single_page")
+
+    response = client.get(
+        reverse("lims_receiving_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert response.status_code == 200
+    assert b'data-floating-action="receiving-single"' in response.content
+    assert receiving_url.encode() in response.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_reference_operation_page_suppresses_fab_without_changing_cards():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-reference-no-fab")
+    reference_page = client.get(
+        reverse("lims_reference_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert reference_page.status_code == 200
+    assert b"data-floating-action=" not in reference_page.content
+    assert b'data-action-card="reference-create-lab"' in reference_page.content
+    assert b'data-action-card="reference-sample-accession"' in reference_page.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_storage_operation_page_filters_actions_by_live_context_and_keeps_fab_authoritative():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-storage-stateful")
+    summary = client.get(
+        "/api/v1/lims/summary", HTTP_HOST=host, HTTP_X_USER_ROLES="tenant.admin"
+    )
+    schema_name = summary.json()["tenant_schema"]
+
+    initial = client.get(
+        reverse("lims_storage_inventory_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert initial.status_code == 200
+    assert b'data-action-card="storage-create-location"' in initial.content
+    assert b'data-action-card="storage-create-material"' in initial.content
+    assert b'data-action-card="storage-record-placement"' not in initial.content
+    assert b'data-action-card="storage-receive-lot"' not in initial.content
+    assert b'data-action-card="storage-record-transaction"' not in initial.content
+    assert b'data-floating-action="storage-create-location"' in initial.content
+
+    with schema_context(schema_name):
+        lab = Lab.objects.create(name="Storage Lab", code="storage-lab")
+        location = StorageLocation.objects.create(
+            lab=lab,
+            name="Main freezer",
+            code="main-freezer",
+            level=StorageLocation.Level.FACILITY,
+        )
+        material = InventoryMaterial.objects.create(
+            name="Cryovial",
+            code="cryovial",
+            category=InventoryMaterial.Category.CONSUMABLE,
+            default_unit="ea",
+        )
+        InventoryLot.objects.create(
+            material=material,
+            lab=lab,
+            storage_location=location,
+            lot_number="LOT-001",
+            initial_quantity=10,
+            on_hand_quantity=10,
+            unit_of_measure="ea",
+        )
+        sample_type = BiospecimenType.objects.create(
+            name="Whole blood",
+            key="whole-blood",
+        )
+        Biospecimen.objects.create(
+            sample_type=sample_type,
+            sample_identifier="SPEC-001",
+            barcode="BC-001",
+            lab=lab,
+        )
+
+    stateful = client.get(
+        reverse("lims_storage_inventory_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert stateful.status_code == 200
+    assert b'data-action-card="storage-create-location"' in stateful.content
+    assert b'data-action-card="storage-create-material"' in stateful.content
+    assert b'data-action-card="storage-record-placement"' in stateful.content
+    assert b'data-action-card="storage-receive-lot"' in stateful.content
+    assert b'data-action-card="storage-record-transaction"' in stateful.content
+    assert b'data-floating-action="storage-create-location"' in stateful.content
 
 
 @pytest.mark.django_db(transaction=True)
@@ -837,7 +976,7 @@ def test_storage_inventory_pages_show_admin_forms():
     assert launchpad.status_code == 200
     assert b"Storage and inventory administration" in launchpad.content
     assert b"Create storage location" in launchpad.content
-    assert b"Record stock transaction" in launchpad.content
+    assert b"Record stock transaction" not in launchpad.content
 
     location_page = client.get(
         reverse("lims_storage_create_location_page"),

--- a/src/tests/test_shell_navigation.py
+++ b/src/tests/test_shell_navigation.py
@@ -387,3 +387,97 @@ def test_resolve_operation_page_uses_descriptor_identity_for_context():
 
     assert operation_page["key"] == "receiving-operations"
     assert [card["key"] for card in operation_page["action_cards"]] == ["stateful-card"]
+    assert operation_page["floating_action"] is None
+
+
+def test_resolve_operation_page_derives_floating_action_from_primary_allowed_card():
+    request = RequestFactory().get("/")
+    operation_page = resolve_operation_page(
+        request,
+        descriptor=OperationPageDescriptor(
+            key="receiving-operations",
+            title="Receiving operations",
+            route_name="lims_receiving_page",
+            fab_enabled=True,
+            action_descriptors=(
+                ActionDescriptor(
+                    key="disabled-primary",
+                    title="Disabled primary",
+                    description="Should not become the FAB.",
+                    icon="block",
+                    route_name="user_portal_dashboard_page",
+                    primary_action=True,
+                    enabled_gate=lambda _context: False,
+                ),
+                ActionDescriptor(
+                    key="single-receipt",
+                    title="Single receipt",
+                    description="Explicit primary action.",
+                    icon="move_to_inbox",
+                    route_name="lims_receiving_single_page",
+                    primary_action=True,
+                ),
+                ActionDescriptor(
+                    key="batch-receipt",
+                    title="Batch receipt",
+                    description="Secondary action.",
+                    icon="upload_file",
+                    route_name="lims_receiving_batch_page",
+                ),
+            ),
+        ),
+    )
+
+    assert [card["key"] for card in operation_page["action_cards"]] == [
+        "disabled-primary",
+        "single-receipt",
+        "batch-receipt",
+    ]
+    assert operation_page["floating_action"] == {
+        "key": "single-receipt",
+        "title": "Single receipt",
+        "icon": "move_to_inbox",
+        "href": reverse("lims_receiving_single_page"),
+        "resolved_url": reverse("lims_receiving_single_page"),
+    }
+
+
+def test_resolve_operation_page_suppresses_fab_without_changing_allowed_cards():
+    request = RequestFactory().get("/")
+    operation_page = resolve_operation_page(
+        request,
+        descriptor=OperationPageDescriptor(
+            key="reference-operations",
+            title="Reference operations",
+            route_name="lims_reference_page",
+            fab_enabled=False,
+            action_descriptors=(
+                ActionDescriptor(
+                    key="create-lab",
+                    title="Create lab",
+                    description="Route backed.",
+                    icon="add_business",
+                    route_name="lims_reference_create_lab_page",
+                ),
+                ActionDescriptor(
+                    key="sample-accession",
+                    title="Provision sample accession",
+                    description="Workflow backed.",
+                    icon="conversion_path",
+                    workflow_key="sample-accession",
+                ),
+            ),
+        ),
+        workflow_entries={
+            "sample-accession": WorkflowEntry(
+                key="sample-accession",
+                href=reverse("lims_reference_sample_accession_page"),
+            )
+        },
+    )
+
+    assert [card["key"] for card in operation_page["action_cards"]] == [
+        "create-lab",
+        "sample-accession",
+    ]
+    assert operation_page["floating_action"] is None

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,8 @@
 # Task Tracking
 
-- Issue #136: implement the reusable action-card component and bounded card-grid rendering contract.
+- Issue #137: implement proving operation pages and FAB derivation from allowed actions.
 - Plan:
-	- extract a shared action-card partial and bounded grid wrapper under `src/core/templates/core/ui/includes/`
-	- convert the repeated LIMS launchpad card markup to the shared includes without reopening resolver logic
-	- add rendering-focused regression coverage for grid and action-card markers in `src/tests/test_lims_ui.py`
-	- run targeted UI tests and the full merge gate
+	- adopt explicit operation-page descriptors on three proving LIMS launchpads: route-heavy receiving, mixed reference, and state-sensitive storage
+	- derive optional FAB behavior from the resolved allowed card set without introducing a second action authority
+	- add resolver and UI regressions proving workflow-backed cards, state-sensitive filtering, and FAB suppression behavior
+	- run targeted navigation and LIMS UI validation before deciding whether a full gate is necessary


### PR DESCRIPTION
## Summary
This PR completes issue #137 by proving the new operation-page contract on three concrete LIMS launchpads and by deriving optional FAB behavior from the same resolved card set.

Implemented surfaces:
- route-heavy proving page: receiving launchpad, with dedicated route-backed action cards and FAB emphasis derived from the primary allowed card
- mixed route-and-workflow proving page: reference launchpad, where route-backed setup actions and the workflow-backed sample accession entry resolve through the same canonical descriptor pipeline
- state-sensitive proving page: storage launchpad, where visible cards change based on live page context such as storage locations, inventory materials, active lots, and placeable artifacts

Why this change is needed now:
- the previous two issues defined descriptor resolution and reusable rendering, but the contract was still unproven on real server-rendered pages
- this PR verifies that route resolution, workflow resolution, context-based filtering, and FAB derivation all work on live pages without introducing page-local action authority

Intentional non-goals:
- no new shell variant or navigation model
- no monitor/dashboard refactor outside the proving surfaces
- no client-side action resolution or standalone FAB definitions

## Review unit
- [x] PR scope maps to exactly one execution issue / implementation slice.
- [x] PR is still small enough for one-pass review.
- [x] PR is draft if any acceptance criteria or validation notes are still incomplete.
- [x] Work was delivered on this branch/PR instead of by direct-to-main implementation.

## Spec Kit artifacts
- [x] Spec path recorded: `specs/012-ontology-driven-operation-pages/spec.md`
- [x] Plan path recorded: `specs/012-ontology-driven-operation-pages/plan.md`
- [x] Tasks path recorded: `specs/012-ontology-driven-operation-pages/tasks.md`
- [x] PR body refreshed from `python .github/scripts/spec_kit_workflow.py pr-body specs/012-ontology-driven-operation-pages`.

## Issue contract
- [x] Linked execution issue: #137.
- [x] Objective, deliverables, acceptance criteria, dependencies, and references are satisfied by the proving-surface adoption and FAB derivation scope in this PR.
- [x] Scope remains bounded to operation-page adoption and rendering behavior; no unrelated shell or monitor refactors were introduced.

## Commit contract
- [x] Branch name uses the repository's Git-safe Conventional Commit slug format.
- [x] Branch commits use Conventional Commit subjects.
- [x] Final integration path for this work is auto-squash after green checks.
- [x] No unrelated refactors, drive-by fixes, or broad rename-only churn are mixed into this PR.

## Handoff contract
- [x] Changed files and risk notes are captured in PR description.
- [x] Done/blocker state is explicit: implementation, local validation, and CI are complete.
- [x] Maintainers can inspect the primary files or behaviors first.

Primary files to inspect first:
- `src/core/navigation.py`: operation-page descriptors, state/data gates, and FAB derivation
- `src/lims/views.py`: proving-surface adoption and page-context wiring
- `src/lims/templates/lims/reference.html`
- `src/lims/templates/lims/receiving.html`
- `src/lims/templates/lims/storage_inventory.html`
- `src/tests/test_shell_navigation.py`
- `src/tests/test_lims_ui.py`

Risk notes:
- the main behavior change is on the storage launchpad, which is now intentionally state-sensitive rather than showing every admin action unconditionally
- FAB authority remains subordinate to the rendered card set; the FAB should never expose an action that is absent from the page cards

## Validation
- [x] `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python .github/scripts/spec_kit_workflow.py validate specs/012-ontology-driven-operation-pages`
- [x] `pytest src/tests/test_shell_navigation.py -q`
- [x] `pytest src/tests/test_lims_ui.py -q`
- [x] `bash .github/scripts/local_fast_feedback.sh --full-gate`
