### PR TITLE
Issue 148: clean up Sample Accession reference and receiving UI migration

### DIFF
--- a/src/core/navigation.py
+++ b/src/core/navigation.py
@@ -302,7 +302,7 @@ REFERENCE_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
     ActionDescriptor(
         key="reference-sample-accession",
         title="Provision sample accession",
-        description="Provision and inspect the canonical sample accession reference bundle used by the receiving adapters.",
+        description="Provision and inspect the canonical sample accession reference bundle that governs runtime execution across receiving adapters.",
         icon="conversion_path",
         workflow_key="sample-accession-reference",
         sequence=50,
@@ -394,7 +394,7 @@ RECEIVING_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
     ActionDescriptor(
         key="receiving-single",
         title="Single sample receipt",
-        description="Capture intake metadata, record a QC accept/reject decision, then log storage or rejection details.",
+        description="Launch the governed Sample Accession runtime from the single-sample receiving adapter, including QC and storage or rejection capture.",
         icon="move_to_inbox",
         route_name="lims_receiving_single_page",
         sequence=10,
@@ -406,7 +406,7 @@ RECEIVING_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
     ActionDescriptor(
         key="receiving-batch",
         title="Batch manifest receipt",
-        description="Download an Excel-friendly CSV template, complete receipt/QC/storage columns, and import the batch.",
+        description="Launch governed Sample Accession runs from a batch manifest import with receipt, QC, and storage or rejection columns.",
         icon="upload_file",
         route_name="lims_receiving_batch_page",
         sequence=20,
@@ -417,7 +417,7 @@ RECEIVING_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
     ActionDescriptor(
         key="receiving-edc-import",
         title="Retrieve from EDC",
-        description="Specify the lab form, expected sample, and external ID, then process the imported record through QC.",
+        description="Launch the governed Sample Accession runtime from an EDC-linked receiving adapter after import, QC, and storage or rejection capture.",
         icon="cloud_download",
         route_name="lims_receiving_edc_import_page",
         sequence=30,

--- a/src/lims/templates/lims/receiving.html
+++ b/src/lims/templates/lims/receiving.html
@@ -12,7 +12,7 @@
 </div>
 
 <section class="panel">
-  {% include "core/ui/includes/panel_header.html" with panel_title="Choose a receiving workflow" panel_description="Operator input starts from a dedicated page per task, rather than a mixed multi-form dashboard." %}
+  {% include "core/ui/includes/panel_header.html" with panel_title="Choose a receiving adapter" panel_description="Each receiving page is an entry adapter into the governed Sample Accession runtime rather than an isolated standalone workflow." %}
   {% include "core/ui/includes/action_card_grid.html" with items=payload.operation_page.action_cards action_namespace="lims" empty_title="No receiving workflows available" empty_description="No receiving workflows are currently available for your role." %}
 </section>
 

--- a/src/lims/templates/lims/reference_sample_accession.html
+++ b/src/lims/templates/lims/reference_sample_accession.html
@@ -8,7 +8,7 @@
 
 {% if payload.capabilities.can_manage_operations %}
 <section class="panel" data-lims-action="reference-sample-accession-provision">
-  {% include "core/ui/includes/panel_header.html" with panel_title="Provision reference bundle" panel_description="Create or repair the canonical sample-accession package, workflow, and published operation used by transitional receiving adapters." %}
+  {% include "core/ui/includes/panel_header.html" with panel_title="Provision reference bundle" panel_description="Create or repair the canonical sample-accession package, workflow, and published operation that governs runtime execution across the receiving adapters." %}
   <div class="button-row">
     <button class="button" type="button" onclick="provisionSampleAccessionBundle()"><span class="material-symbols-outlined button-icon" aria-hidden="true">conversion_path</span><span>Provision sample accession bundle</span></button>
     <a class="button button-secondary" href="{{ lims_reference_url }}">Back to reference</a>
@@ -17,7 +17,7 @@
 {% endif %}
 
 <section class="panel">
-  {% include "core/ui/includes/panel_header.html" with panel_title="Current reference status" panel_description="Published bundle state and adapter activity update on demand after provisioning." %}
+  {% include "core/ui/includes/panel_header.html" with panel_title="Current reference status" panel_description="Published bundle state and governed runtime activity update on demand after provisioning." %}
   <div class="stat-grid">
     <article class="card"><strong>Form package</strong><p data-sample-accession-package-status>{% if payload.reference_bundle %}Published v{{ payload.cards.package_version }}{% else %}Not provisioned{% endif %}</p></article>
     <article class="card"><strong>Workflow</strong><p data-sample-accession-workflow-status>{% if payload.reference_bundle %}Published v{{ payload.cards.workflow_version }}{% else %}Not provisioned{% endif %}</p></article>
@@ -28,7 +28,7 @@
 
 <div class="cards" style="grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));">
   <section class="panel">
-    {% include "core/ui/includes/panel_header.html" with panel_title="Reference contract" panel_description="Canonical codes, supported source modes, and transitional adapter targets." %}
+    {% include "core/ui/includes/panel_header.html" with panel_title="Reference contract" panel_description="Canonical codes, supported source modes, and the governed runtime relationship exposed through receiving adapters." %}
     <div data-sample-accession-contract>
       {% if payload.reference_bundle %}
       <div class="section-stack">

--- a/src/lims/views.py
+++ b/src/lims/views.py
@@ -590,7 +590,7 @@ def _reference_sample_accession_page_payload(request) -> dict[str, object]:
         request,
         active_key="lims-reference",
         title="Sample accession reference bundle",
-        summary="Provision and inspect the canonical form package, workflow, operation, and recent governed runs behind receiving adapters.",
+        summary="Provision and inspect the canonical reference bundle that governs Sample Accession runtime execution across the receiving adapters.",
         kicker="Reference operation",
     )
     form_package = (
@@ -993,7 +993,7 @@ def _receiving_launchpad_payload(request) -> dict[str, object]:
         request,
         active_key="lims-receiving",
         title="Receiving and accessioning",
-        summary="Choose a focused receiving flow, then complete that task on a dedicated one-form page.",
+        summary="Choose a receiving adapter. Each path launches the governed Sample Accession runtime from a dedicated entry page.",
         kicker="Accessioning",
     )
     payload["cards"] = {
@@ -1033,7 +1033,7 @@ def _receiving_single_page_payload(request) -> dict[str, object]:
         request,
         active_key="lims-receiving",
         title="Receive single specimen",
-        summary="Capture initial metadata, complete the first QC decision, then log storage or document a rejection.",
+        summary="Use this receiving adapter to launch the governed Sample Accession runtime, capture initial receipt data, complete QC, and log storage or rejection.",
         kicker="Single receipt",
     )
     payload["sample_type_options"] = [
@@ -1061,7 +1061,7 @@ def _receiving_batch_page_payload(request) -> dict[str, object]:
         request,
         active_key="lims-receiving",
         title="Receive batch manifest",
-        summary="Use one batch import form to load intake metadata, QC outcomes, and storage instructions from a template.",
+        summary="Use this receiving adapter to launch governed Sample Accession runs from one batch import template with intake, QC, and storage or rejection outcomes.",
         kicker="Batch receipt",
     )
     payload["sample_type_options"] = [
@@ -1094,7 +1094,7 @@ def _receiving_edc_import_page_payload(request) -> dict[str, object]:
         request,
         active_key="lims-receiving",
         title="Retrieve metadata from EDC",
-        summary="Capture the lab form, expected sample, external ID import target, and QC/storage outcome in one flow.",
+        summary="Use this receiving adapter to import EDC context, then launch the governed Sample Accession runtime with QC and storage or rejection outcome capture.",
         kicker="EDC intake",
     )
     payload["sample_type_options"] = [

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -172,7 +172,7 @@ def test_lims_html_pages_render_with_role_aware_actions():
         (
             reverse("lims_receiving_page"),
             b"Receiving and accessioning",
-            b"Choose a receiving workflow",
+            b"Choose a receiving adapter",
         ),
         (
             reverse("lims_receiving_single_page"),
@@ -332,6 +332,62 @@ def test_reference_launchpad_renders_sample_accession_workflow_entry():
     assert response.status_code == 200
     assert b"Provision sample accession" in response.content
     assert sample_accession_url.encode() in response.content
+
+
+@pytest.mark.django_db(transaction=True)
+def test_sample_accession_ui_surfaces_explain_governed_runtime_relationship():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-sample-accession-migration-copy")
+
+    reference_page = client.get(
+        reverse("lims_reference_sample_accession_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    receiving_page = client.get(
+        reverse("lims_receiving_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    single_page = client.get(
+        reverse("lims_receiving_single_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    batch_page = client.get(
+        reverse("lims_receiving_batch_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    edc_page = client.get(
+        reverse("lims_receiving_edc_import_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert reference_page.status_code == 200
+    assert (
+        b"governs runtime execution across the receiving adapters"
+        in reference_page.content
+    )
+
+    assert receiving_page.status_code == 200
+    assert (
+        b"entry adapter into the governed Sample Accession runtime"
+        in receiving_page.content
+    )
+
+    assert single_page.status_code == 200
+    assert b"launch the governed Sample Accession runtime" in single_page.content
+
+    assert batch_page.status_code == 200
+    assert b"launch governed Sample Accession runs" in batch_page.content
+
+    assert edc_page.status_code == 200
+    assert (
+        b"import EDC context, then launch the governed Sample Accession runtime"
+        in edc_page.content
+    )
 
 
 @pytest.mark.django_db(transaction=True)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,8 +1,8 @@
 # Task Tracking
 
-- Issue #147: harden Sample Accession receiving adapters to governed runtime.
+- Issue #148: clean up Sample Accession reference and receiving UI migration.
 - Plan:
-	- inspect the current Sample Accession single, batch, and EDC adapter paths in `src/lims/services.py` and related APIs/tests to find where governed runtime evidence still differs by initiation mode
-	- keep the scope limited to runtime adapter behavior, explicit accepted or rejected branch handling, and auditable submission or discrepancy outcomes without drifting into reference-bundle or UI cleanup work
-	- implement the smallest behavior-safe hardening needed to make adapter parity across initiation modes explicit in `OperationRun`, `TaskRun`, `SubmissionRecord`, approvals, discrepancies, and storage or disposition outcomes
-	- add focused tests proving governed runtime parity and explicit branch evidence across the affected Sample Accession initiation modes
+	- inspect the current Sample Accession reference page, receiving launchpad, and receiving entry pages to find where transitional and governed-runtime ownership language is still mixed
+	- keep the scope limited to UI copy, page payload language, and focused UI assertions without drifting into runtime services or reference-bundle logic
+	- implement the smallest behavior-safe wording and presentation updates needed to make governed runtime ownership and receiving-adapter semantics explicit
+	- add focused UI tests covering the resulting reference-operation and receiving migration language


### PR DESCRIPTION
## Review Unit
- Issue #148: clean up Sample Accession reference and receiving UI migration

## Summary
- clarify that the Sample Accession reference page owns the canonical governed runtime contract rather than a standalone receiving-era bundle
- reword receiving launchpad and entry surfaces so single, batch, and EDC pages are presented as adapters that launch governed Sample Accession runtime work
- extend focused UI coverage for the resulting migration language on the reference page, receiving launchpad, and receiving entry pages

## Spec Kit Artifacts
- Spec: `specs/006-sample-accession-reference-operation/spec.md`
- Plan: `specs/006-sample-accession-reference-operation/plan.md`
- Tasks: `specs/006-sample-accession-reference-operation/tasks.md`
- Linked issue: #148

## Issue Contract
- Objective, deliverables, acceptance criteria, dependencies, and references are defined in issue #148
- Scope is limited to Sample Accession reference and receiving UI migration clarity without changing runtime services or bundle semantics

## Commit Contract
- Branch: `feat/sample-accession-ui-migration-cleanup`
- Commit: `8c442be` `feat(lims): clarify sample accession ui migration`
- Changed files: `src/core/navigation.py`, `src/lims/views.py`, `src/lims/templates/lims/reference_sample_accession.html`, `src/lims/templates/lims/receiving.html`, `src/tests/test_lims_ui.py`, `tasks/todo.md`

## Handoff Contract
- Changed-file risk is limited to server-rendered UI copy and the related action-card descriptions and assertions
- Done state for this slice: the reference bundle page now explains governed runtime ownership, and receiving launchpad and entry pages now explain adapter semantics explicitly
- No spec bundle update was required because implementation stayed inside the existing issue #148 boundary

## Validation
- `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python -m pytest tests/test_lims_ui.py -q`
- `/home/jmduda/KodeX.2026/mtafiti/.venv/bin/python -m pytest tests/test_shell_navigation.py -q`
- `bash .github/scripts/local_fast_feedback.sh --full-gate`

## Linked Issue
- Closes #148