### PR TITLE
docs(workflow): require clean main before branching

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,6 +9,8 @@
 * Start implementation work from a dedicated issue branch; do not make normal delivery changes on `main`.
 * Open or refresh the matching pull request for that branch and keep it in draft until scope, acceptance criteria, and validation notes are current.
 * Merge implementation work by auto-squash after required checks pass; do not treat direct-to-`main` commits as a normal completion path.
+* After every successful merge, clean merged local branches, prune removed remote refs, and sync back to `main` before starting the next slice.
+* Before creating a new implementation branch, ensure the local environment is clean: `main` checked out, working tree clean, and no stale merged branches left behind.
 * Do not wait for an additional review gate after all required workflow checks are green unless the operator explicitly asks for review.
 
 ## Verification contract

--- a/docs/self-reflective-implementation.md
+++ b/docs/self-reflective-implementation.md
@@ -150,6 +150,8 @@ Treat the PR, not the branch commit list, as the primary review unit.
 * Mark the PR ready only when the description, validation notes, and risk handoff are current.
 * Human review is optional and should be requested only when the operator asks for it or the change is unusually risky.
 * Prefer squash merge so green PRs yield a clean `main` history without requiring branch-local commit curation.
+* After a successful merge, switch back to `main`, prune removed remote refs, delete merged local branches that are no longer needed, and sync local `main` before starting the next issue.
+* Treat branch creation as blocked until the local environment is clean: `main` checked out, working tree clean, and no stale merged branches lingering from prior slices.
 * If the local branch accumulates unrelated stacked commits or the local git transport cannot publish, create a clean branch from `main` and publish only the scoped files through the repository PR tooling instead of waiting or rewriting shared history on `main`.
 
 Maintainers who need to enforce the same merge contract at the repository-settings level should use the branch-protection runbook in `docs/operations-runbooks.md` and the helper at `.github/scripts/configure_branch_protection.py` instead of editing GitHub settings ad hoc.

--- a/templates/agentic-workflow/.github/copilot-instructions.md
+++ b/templates/agentic-workflow/.github/copilot-instructions.md
@@ -9,6 +9,8 @@
 * Start implementation work from a dedicated issue branch; do not make normal delivery changes on `main`.
 * Open or refresh the matching pull request for that branch and keep it in draft until scope, acceptance criteria, and validation notes are current.
 * Merge implementation work by auto-squash after required checks pass; do not treat direct-to-`main` commits as a normal completion path.
+* After every successful merge, clean merged local branches, prune removed remote refs, and sync back to `main` before starting the next slice.
+* Before creating a new implementation branch, ensure the local environment is clean: `main` checked out, working tree clean, and no stale merged branches left behind.
 * Do not wait for an additional review gate after all required workflow checks are green unless the operator explicitly asks for review.
 
 ## Verification contract


### PR DESCRIPTION
# Pull Request

## Summary

Describe what this PR changes, why it is needed now, and what is intentionally left out of scope.

## Review unit

- [ ] PR scope maps to exactly one execution issue / implementation slice.
- [ ] PR is still small enough for one-pass review.
- [ ] PR is draft if any acceptance criteria or validation notes are still incomplete.
- [ ] Work was delivered on this branch/PR instead of by direct-to-`main` implementation.

## Spec Kit artifacts

- [ ] Spec path recorded.
- [ ] Plan path recorded.
- [ ] Tasks path recorded.
- [ ] PR body refreshed from `python .github/scripts/spec_kit_workflow.py pr-body specs/<feature-dir>`.

## Issue contract

- [ ] Linked execution issue includes Objective, Deliverables, Acceptance Criteria, Dependencies, and References.
- [ ] Scope boundary for this PR is explicit and matches the issue deliverables.

## Commit contract

- [ ] Branch name uses the repository's Git-safe Conventional Commit slug format.
- [ ] Branch commits use Conventional Commit subjects.
- [ ] Final integration path for this work is auto-squash after green checks.
- [ ] No unrelated refactors, drive-by fixes, or broad rename-only churn are mixed into this PR.

## Handoff contract

- [ ] Changed files and risk notes are captured in PR description.
- [ ] Done/blocker state is explicit (no implicit “follow-up later” gaps).
- [ ] Maintainers can see the primary files or behaviors to inspect first.

## Documentation chunk

- [ ] This docs PR is a meaningful batch (target: 3+ docs files when docs-only).
- [ ] Chunk selected: Platform core / Execution modules / Security & ops / Governance domains.
- [ ] Roadmap and README links are updated together when new design docs are introduced.
- [ ] Acceptance criteria and non-goals are present in each newly added design doc.
- [ ] Cross-doc references are updated so the chunk is reviewable end-to-end in one pass.

## Validation

- [ ] Ran tests/checks relevant to this change.
- [ ] Listed the concrete commands or manual checks used for validation in the PR body.
