### PR TITLE
Issue 131: implement django-material shell proving surfaces

### DIFF
--- a/src/lims/templates/lims/dashboard.html
+++ b/src/lims/templates/lims/dashboard.html
@@ -4,6 +4,22 @@
 {% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Workspace" current_label="LIMS dashboard" %}
 {% endblock %}
 
+{% block page_actions %}
+<a class="button button-secondary" href="{% url 'lims_task_inbox_page' %}" data-lims-shell-action="dashboard-task-inbox">
+  <span class="material-symbols-outlined button-icon" aria-hidden="true">task</span>
+  <span>Open task inbox</span>
+</a>
+<a class="button button-secondary" href="{% url 'lims_reference_page' %}" data-lims-shell-action="dashboard-reference">
+  <span class="material-symbols-outlined button-icon" aria-hidden="true">account_tree</span>
+  <span>Open reference</span>
+</a>
+{% endblock %}
+
+{% block workflow_guidance %}
+{% include "core/ui/includes/panel_header.html" with panel_title="Workflow guidance" panel_description="Use the launchpad for area entry, then move into task inbox or focused CRUD pages without leaving the shared shell contract." %}
+<p class="muted">Dashboard actions stay in the shell action slot, while operational content stays in the main page slot.</p>
+{% endblock %}
+
 {% block page_content %}
 <div class="stat-grid">
   {% include "core/ui/includes/count_stat_card.html" with card_title="Labs" count_label="records" count_value=payload.cards.labs link_href=payload.card_links.reference.href link_label="Open reference" %}

--- a/src/lims/templates/lims/reference_create_lab.html
+++ b/src/lims/templates/lims/reference_create_lab.html
@@ -1,10 +1,24 @@
 {% extends "lims/base.html" %}
 
-{% block content %}
+{% block page_heading %}
 {% url 'lims_reference_page' as lims_reference_url %}
-{% url 'lims:reference_select_options' as lims_reference_select_options_url %}
 {% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="Reference" parent_url=lims_reference_url current_label="Create lab" %}
+{% endblock %}
 
+{% block page_actions %}
+{% url 'lims_reference_page' as lims_reference_url %}
+<a class="button button-secondary" href="{{ lims_reference_url }}" data-lims-shell-action="reference-lab-back">
+  <span class="material-symbols-outlined button-icon" aria-hidden="true">arrow_back</span>
+  <span>Back to reference</span>
+</a>
+<a class="button button-secondary" href="{% url 'lims_dashboard_page' %}" data-lims-shell-action="reference-lab-dashboard">
+  <span class="material-symbols-outlined button-icon" aria-hidden="true">dashboard</span>
+  <span>Open dashboard</span>
+</a>
+{% endblock %}
+
+{% block page_content %}
+{% url 'lims:reference_select_options' as lims_reference_select_options_url %}
 {% if payload.capabilities.can_manage_reference %}
 <section class="panel" data-lims-action="reference-lab-create">
   {% include "core/ui/includes/panel_header.html" with panel_title="Lab setup form" panel_description="Capture one tenant lab at a time, including its address." %}
@@ -16,7 +30,6 @@
     <p class="muted">Selecting a street will automatically infer ward, district, region, country, and postcode when possible.</p>
     <div class="button-row">
       <button class="button" type="button" onclick="createLab()"><span class="material-symbols-outlined button-icon" aria-hidden="true">add_business</span><span>Create lab</span></button>
-      <a class="button button-secondary" href="{{ lims_reference_url }}">Back to reference</a>
     </div>
   </div>
 </section>

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -319,6 +319,39 @@ def test_reference_forms_expose_slug_and_address_selectors():
 
 
 @pytest.mark.django_db(transaction=True)
+def test_shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-shell-proving-surfaces")
+
+    dashboard = client.get(
+        reverse("lims_dashboard_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    create_lab = client.get(
+        reverse("lims_reference_create_lab_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert dashboard.status_code == 200
+    assert b'data-shell-slot="heading"' in dashboard.content
+    assert b'data-shell-slot="actions"' in dashboard.content
+    assert b'data-shell-slot="workflow-guidance"' in dashboard.content
+    assert b'data-shell-slot="main-content"' in dashboard.content
+    assert b'data-lims-shell-action="dashboard-task-inbox"' in dashboard.content
+    assert b"Workflow guidance" in dashboard.content
+
+    assert create_lab.status_code == 200
+    assert b'data-shell-slot="heading"' in create_lab.content
+    assert b'data-shell-slot="actions"' in create_lab.content
+    assert b'data-shell-slot="main-content"' in create_lab.content
+    assert b'data-lims-shell-action="reference-lab-back"' in create_lab.content
+    assert b'data-lims-shell-action="reference-lab-dashboard"' in create_lab.content
+    assert b'data-lims-action="reference-lab-create"' in create_lab.content
+
+
+@pytest.mark.django_db(transaction=True)
 def test_reference_launchpad_renders_sample_accession_workflow_entry():
     client = Client()
     host = _create_lims_host(client, "tenant-ui-reference-workflow-entry")

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,12 +1,13 @@
 # Task Tracking
 
-- Cleanup review completed after merged Sample Accession follow-on slices.
-- Status:
-	- PR #151 merged; issue #148 closed.
-	- Umbrella issue #111 closed because the split execution slices #146, #147, and #148 are now merged.
-	- Local `main` is synced through the merged Sample Accession UI cleanup.
-- Task review:
-	- Issue #130 remains the open parent/specification tracker for the ontology-driven admin shell.
-	- Issue #131 is the most likely next implementation-ready coding slice because it establishes the shared django-material shell contract that issue #133 builds on.
-	- Issue #133 appears downstream of the shared shell/action-slot contract and is not the best next slice before #131.
-	- Older issues #87, #88, #89, and #90 remain broader backlog items rather than the smallest next reviewable slice.
+- Issue #131: implement django-material admin shell contract and proving surfaces.
+- Status: completed local implementation on `feat/django-material-shell-proving-surfaces`.
+- Delivered:
+  - promoted `lims_dashboard_page` to an explicit proving surface for the shared shell `page_actions` and `workflow_guidance` slots
+  - promoted `lims_reference_create_lab_page` to an explicit proving surface for the shared shell `page_heading`, `page_actions`, and `page_content` slots
+  - kept the create-lab reference selector URL contract intact while moving the page onto shell-slot blocks
+  - added focused UI regression coverage for dashboard and CRUD shell-slot rendering
+- Validation:
+  - `../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'reference_forms_expose_slug_and_address_selectors or shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud'`
+  - `../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'lims_html_pages_render_with_role_aware_actions or shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud'`
+  - pending full gate: `.github/scripts/local_fast_feedback.sh --full-gate`


### PR DESCRIPTION
# Pull Request

## Summary

- implement the smallest issue-131 shell proof by making the LIMS dashboard and create-lab reference page use explicit shared shell slots
- keep the scope at the template proving layer rather than expanding descriptor-registry or FAB behavior work that belongs to adjacent issues
- add focused UI regression coverage for the dashboard and CRUD proving surfaces

## Review unit

- [x] PR scope maps to exactly one execution issue / implementation slice.
- [x] PR is still small enough for one-pass review.
- [x] PR is draft if any acceptance criteria or validation notes are still incomplete.
- [x] Work was delivered on this branch/PR instead of by direct-to-main implementation.

## Spec Kit artifacts

- [ ] Spec path recorded.
- [ ] Plan path recorded.
- [ ] Tasks path recorded.
- [ ] PR body refreshed from `python .github/scripts/spec_kit_workflow.py pr-body specs/<feature-dir>`.
- issue #131 was defined from the ontology-driven admin shell issue contract, but the referenced `specs/011-ontology-driven-admin-shell/` bundle is not present in the repository.

## Issue contract

- [x] Linked execution issue includes Objective, Deliverables, Acceptance Criteria, Dependencies, and References.
- [x] Scope boundary for this PR is explicit and matches the issue deliverables.
- execution issue: #131

## Commit contract

- [x] Branch name uses the repository's Git-safe Conventional Commit slug format.
- [x] Branch commits use Conventional Commit subjects.
- [x] Final integration path for this work is auto-squash after green checks.
- [x] No unrelated refactors, drive-by fixes, or broad rename-only churn are mixed into this PR.

## Handoff contract

- [x] Changed files and risk notes are captured in PR description.
- [x] Done/blocker state is explicit (no implicit follow-up later gaps).
- [x] Maintainers can see the primary files or behaviors to inspect first.
- inspect first: `src/lims/templates/lims/dashboard.html`, `src/lims/templates/lims/reference_create_lab.html`, and `src/tests/test_lims_ui.py`
- risk notes: this is intentionally limited to the dashboard and create-lab proving surfaces; navigation descriptors and FAB/shared action-slot behavior remain with adjacent issue slices.

## Documentation chunk

- [ ] This docs PR is a meaningful batch (target: 3+ docs files when docs-only).
- [ ] Chunk selected: Platform core / Execution modules / Security & ops / Governance domains.
- [ ] Roadmap and README links are updated together when new design docs are introduced.
- [ ] Acceptance criteria and non-goals are present in each newly added design doc.
- [ ] Cross-doc references are updated so the chunk is reviewable end-to-end in one pass.
- not a docs-only PR.

## Validation

- [x] Ran tests/checks relevant to this change.
- [x] Listed the concrete commands or manual checks used for validation in the PR body.
- `cd /home/jmduda/KodeX.2026/mtafiti/src && ../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'reference_forms_expose_slug_and_address_selectors or shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud'`
- `cd /home/jmduda/KodeX.2026/mtafiti/src && ../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'lims_html_pages_render_with_role_aware_actions or shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud'`
- `cd /home/jmduda/KodeX.2026/mtafiti && bash .github/scripts/local_fast_feedback.sh --full-gate`
- full gate result: 296 passed, 2 deselected
