### PR TITLE
Issue 133: implement reusable FAB and shared action-slot behavior

### DIFF
--- a/src/core/navigation.py
+++ b/src/core/navigation.py
@@ -86,6 +86,7 @@ class OperationPageDescriptor:
     navigation_key: str | None = None
     action_descriptors: tuple[ActionDescriptor, ...] = ()
     fab_enabled: bool = False
+    shared_action_slot_enabled: bool = False
 
     def __post_init__(self) -> None:
         if not self.route_name and not self.navigation_key:
@@ -346,6 +347,16 @@ TASK_INBOX_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
 )
 
 
+TASK_INBOX_OPERATION_PAGE_DESCRIPTOR = OperationPageDescriptor(
+    key="lims-tasks",
+    title="Workflow task inbox",
+    route_name="lims_task_inbox_page",
+    navigation_key="lims-tasks",
+    action_descriptors=TASK_INBOX_ACTION_DESCRIPTORS,
+    shared_action_slot_enabled=True,
+)
+
+
 METADATA_ACTION_DESCRIPTORS: tuple[ActionDescriptor, ...] = (
     ActionDescriptor(
         key="metadata-create-vocabulary",
@@ -435,6 +446,7 @@ RECEIVING_OPERATION_PAGE_DESCRIPTOR = OperationPageDescriptor(
     navigation_key="lims-receiving",
     action_descriptors=RECEIVING_ACTION_DESCRIPTORS,
     fab_enabled=True,
+    shared_action_slot_enabled=True,
 )
 
 
@@ -791,11 +803,27 @@ def resolve_operation_page(
         "route_name": descriptor.route_name,
         "navigation_key": descriptor.navigation_key,
         "action_cards": action_cards,
+        "shared_action_slot": derive_operation_action_slot(
+            action_cards,
+            enabled=descriptor.shared_action_slot_enabled,
+        ),
         "floating_action": derive_operation_fab(
             action_cards,
             enabled=descriptor.fab_enabled,
         ),
     }
+
+
+def derive_operation_action_slot(
+    action_cards: Iterable[Mapping[str, Any]], *, enabled: bool
+) -> list[dict[str, Any]]:
+    if not enabled:
+        return []
+    return [
+        dict(card)
+        for card in action_cards
+        if card.get("enabled", True) and (card.get("resolved_url") or card.get("href"))
+    ]
 
 
 def derive_operation_fab(

--- a/src/core/templates/core/ui/includes/shared_action_slot.html
+++ b/src/core/templates/core/ui/includes/shared_action_slot.html
@@ -1,0 +1,17 @@
+{% if items %}
+<div class="button-row" data-shell-action-slot="{{ action_namespace|default:'ui' }}">
+  {% for item in items %}
+  {% with resolved_url=item.resolved_url|default:item.href %}
+  {% if resolved_url %}
+  <a class="button{% if not item.primary_action %} button-secondary{% endif %}"
+     href="{{ resolved_url }}"
+     data-action-slot-item="{{ item.key }}"
+     {% if action_namespace == "lims" %}data-lims-action-slot="{{ item.key }}"{% endif %}>
+    <span class="material-symbols-outlined button-icon" aria-hidden="true">{{ item.icon|default:"arrow_forward" }}</span>
+    <span>{{ item.title }}</span>
+  </a>
+  {% endif %}
+  {% endwith %}
+  {% endfor %}
+</div>
+{% endif %}

--- a/src/lims/templates/lims/receiving.html
+++ b/src/lims/templates/lims/receiving.html
@@ -1,5 +1,9 @@
 {% extends "lims/base.html" %}
 
+{% block page_actions %}
+  {% include "core/ui/includes/shared_action_slot.html" with items=payload.operation_page.shared_action_slot action_namespace="lims" %}
+{% endblock %}
+
 {% block content %}
 {% url 'lims_dashboard_page' as lims_dashboard_url %}
 {% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="LIMS" parent_url=lims_dashboard_url current_label="Receiving" %}

--- a/src/lims/templates/lims/task_inbox.html
+++ b/src/lims/templates/lims/task_inbox.html
@@ -1,5 +1,9 @@
 {% extends "lims/base.html" %}
 
+{% block page_actions %}
+  {% include "core/ui/includes/shared_action_slot.html" with items=payload.operation_page.shared_action_slot action_namespace="lims" %}
+{% endblock %}
+
 {% block content %}
 {% url 'lims_dashboard_page' as lims_dashboard_url %}
 {% include "core/ui/includes/page_intro.html" with section_label=payload.page.kicker page_title=payload.page.page_title page_summary=payload.page.page_summary parent_label="LIMS" parent_url=lims_dashboard_url current_label="Tasks" %}

--- a/src/lims/views.py
+++ b/src/lims/views.py
@@ -20,7 +20,7 @@ from core.navigation import (
     RECEIVING_OPERATION_PAGE_DESCRIPTOR,
     REFERENCE_OPERATION_PAGE_DESCRIPTOR,
     STORAGE_OPERATION_PAGE_DESCRIPTOR,
-    TASK_INBOX_ACTION_DESCRIPTORS,
+    TASK_INBOX_OPERATION_PAGE_DESCRIPTOR,
     WORKSPACE_NAVIGATION_DESCRIPTORS,
     resolve_action_descriptors,
     resolve_navigation,
@@ -481,12 +481,11 @@ def _task_inbox_page_payload(request) -> dict[str, object]:
             ]
         ).count(),
     }
-    payload["actions"] = resolve_action_descriptors(
+    payload["operation_page"] = resolve_operation_page(
         request,
-        descriptors=TASK_INBOX_ACTION_DESCRIPTORS,
-        page_key="lims-tasks",
-        route_name="lims_task_inbox_page",
+        descriptor=TASK_INBOX_OPERATION_PAGE_DESCRIPTOR,
     )
+    payload["actions"] = payload["operation_page"]["action_cards"]
     payload["open_tasks"] = open_tasks
     payload["approval_tasks"] = approval_tasks
     payload["recent_runs"] = [

--- a/src/tests/test_lims_ui.py
+++ b/src/tests/test_lims_ui.py
@@ -574,6 +574,37 @@ def test_reference_operation_page_suppresses_fab_without_changing_cards():
 
 
 @pytest.mark.django_db(transaction=True)
+def test_receiving_and_task_inbox_pages_render_shared_action_slot_behavior():
+    client = Client()
+    host = _create_lims_host(client, "tenant-ui-shared-action-slot")
+    sample_accession_url = reverse("lims_reference_sample_accession_page")
+
+    receiving = client.get(
+        reverse("lims_receiving_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+    task_inbox = client.get(
+        reverse("lims_task_inbox_page"),
+        HTTP_HOST=host,
+        HTTP_X_USER_ROLES="tenant.admin",
+    )
+
+    assert receiving.status_code == 200
+    assert b'data-shell-action-slot="lims"' in receiving.content
+    assert b'data-action-slot-item="receiving-single"' in receiving.content
+    assert b'data-action-slot-item="receiving-batch"' in receiving.content
+    assert b'data-floating-action="receiving-single"' in receiving.content
+
+    assert task_inbox.status_code == 200
+    assert b'data-shell-action-slot="lims"' in task_inbox.content
+    assert b'data-action-slot-item="task-open-receiving"' in task_inbox.content
+    assert b'data-action-slot-item="task-inspect-operations"' in task_inbox.content
+    assert sample_accession_url.encode() in task_inbox.content
+    assert b"data-floating-action=" not in task_inbox.content
+
+
+@pytest.mark.django_db(transaction=True)
 def test_storage_operation_page_filters_actions_by_live_context_and_keeps_fab_authoritative():
     client = Client()
     host = _create_lims_host(client, "tenant-ui-storage-stateful")

--- a/src/tests/test_shell_navigation.py
+++ b/src/tests/test_shell_navigation.py
@@ -442,6 +442,100 @@ def test_resolve_operation_page_derives_floating_action_from_primary_allowed_car
     }
 
 
+def test_resolve_operation_page_derives_shared_action_slot_from_allowed_cards():
+    request = RequestFactory().get("/")
+    operation_page = resolve_operation_page(
+        request,
+        descriptor=OperationPageDescriptor(
+            key="receiving-operations",
+            title="Receiving operations",
+            route_name="lims_receiving_page",
+            fab_enabled=True,
+            shared_action_slot_enabled=True,
+            action_descriptors=(
+                ActionDescriptor(
+                    key="disabled-primary",
+                    title="Disabled primary",
+                    description="Should not appear in the shared action slot.",
+                    icon="block",
+                    route_name="user_portal_dashboard_page",
+                    primary_action=True,
+                    enabled_gate=lambda _context: False,
+                ),
+                ActionDescriptor(
+                    key="single-receipt",
+                    title="Single receipt",
+                    description="Explicit primary action.",
+                    icon="move_to_inbox",
+                    route_name="lims_receiving_single_page",
+                    primary_action=True,
+                ),
+                ActionDescriptor(
+                    key="batch-receipt",
+                    title="Batch receipt",
+                    description="Secondary action.",
+                    icon="upload_file",
+                    route_name="lims_receiving_batch_page",
+                ),
+            ),
+        ),
+    )
+
+    assert [item["key"] for item in operation_page["shared_action_slot"]] == [
+        "single-receipt",
+        "batch-receipt",
+    ]
+    assert operation_page["shared_action_slot"][0]["resolved_url"] == reverse(
+        "lims_receiving_single_page"
+    )
+
+
+def test_resolve_operation_page_shared_action_slot_keeps_workflow_urls_server_side():
+    request = RequestFactory().get("/")
+    sample_accession_url = reverse("lims_reference_sample_accession_page")
+    operation_page = resolve_operation_page(
+        request,
+        descriptor=OperationPageDescriptor(
+            key="task-inbox",
+            title="Task inbox",
+            route_name="lims_task_inbox_page",
+            shared_action_slot_enabled=True,
+            action_descriptors=(
+                ActionDescriptor(
+                    key="inspect-operations",
+                    title="Inspect operations",
+                    description="Workflow-backed action.",
+                    icon="conversion_path",
+                    workflow_key="sample-accession",
+                ),
+            ),
+        ),
+        workflow_entries={
+            "sample-accession": WorkflowEntry(
+                key="sample-accession",
+                href=sample_accession_url,
+            )
+        },
+    )
+
+    assert operation_page["shared_action_slot"] == [
+        {
+            "key": "inspect-operations",
+            "title": "Inspect operations",
+            "description": "Workflow-backed action.",
+            "icon": "conversion_path",
+            "href": sample_accession_url,
+            "resolved_url": sample_accession_url,
+            "enabled": True,
+            "status": None,
+            "sequence": None,
+            "primary_action": False,
+            "workflow_key": "sample-accession",
+            "route_name": None,
+        }
+    ]
+
+
 def test_resolve_operation_page_suppresses_fab_without_changing_allowed_cards():
     request = RequestFactory().get("/")
     operation_page = resolve_operation_page(

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,13 +1,14 @@
 # Task Tracking
 
-- Issue #131: implement django-material admin shell contract and proving surfaces.
-- Status: completed local implementation on `feat/django-material-shell-proving-surfaces`.
+- Issue #133: implement reusable FAB and shared action-slot workflow behavior.
+- Status: completed local implementation on `feat/reusable-fab-action-slot-workflow-behavior`.
 - Delivered:
-  - promoted `lims_dashboard_page` to an explicit proving surface for the shared shell `page_actions` and `workflow_guidance` slots
-  - promoted `lims_reference_create_lab_page` to an explicit proving surface for the shared shell `page_heading`, `page_actions`, and `page_content` slots
-  - kept the create-lab reference selector URL contract intact while moving the page onto shell-slot blocks
-  - added focused UI regression coverage for dashboard and CRUD shell-slot rendering
+  - extended the resolved operation-page pipeline so one descriptor set can derive both FAB output and a shared non-floating action-slot payload from the same allowed actions
+  - kept workflow resolution server-side by reusing resolved `route_name` and `workflow_key` outputs instead of constructing workflow URLs in templates or client code
+  - proved the behavior on the receiving launchpad as the FAB-authoritative surface and the task inbox as the shared action-slot fallback surface
+  - added focused resolver and UI regressions for shared action-slot derivation, workflow-backed actions, and FAB plus fallback consistency
 - Validation:
-  - `../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'reference_forms_expose_slug_and_address_selectors or shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud'`
-  - `../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'lims_html_pages_render_with_role_aware_actions or shell_proving_surfaces_render_shared_slots_for_dashboard_and_crud'`
-  - pending full gate: `.github/scripts/local_fast_feedback.sh --full-gate`
+  - `../.venv/bin/python -m pytest tests/test_shell_navigation.py -q`
+  - `../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'receiving_operation_page_derives_fab_from_primary_action or reference_operation_page_suppresses_fab_without_changing_cards or receiving_and_task_inbox_pages_render_shared_action_slot_behavior'`
+  - `../.venv/bin/python -m pytest tests/test_lims_ui.py -q`
+  - `bash .github/scripts/local_fast_feedback.sh --full-gate` → `299 passed, 2 deselected`


### PR DESCRIPTION
# Pull Request

## Summary

- implement the minimal issue-133 resolver extension so operation pages can derive a shared non-floating action-slot payload from the same allowed actions that already drive FAB behavior
- keep workflow routing server-side by reusing resolved `route_name` and `workflow_key` outputs instead of constructing workflow URLs in templates or client code
- prove the behavior on the receiving launchpad as the FAB-authoritative surface and the workflow task inbox as the shared action-slot fallback surface

## Review unit

- [x] PR scope maps to exactly one execution issue / implementation slice.
- [x] PR is still small enough for one-pass review.
- [x] PR is draft if any acceptance criteria or validation notes are still incomplete.
- [x] Work was delivered on this branch/PR instead of by direct-to-`main` implementation.

## Spec Kit artifacts

- [x] Spec path recorded.
- [x] Plan path recorded.
- [x] Tasks path recorded.
- [ ] PR body refreshed from `python .github/scripts/spec_kit_workflow.py pr-body specs/<feature-dir>`.
- Spec: `specs/011-ontology-driven-admin-shell/spec.md`
- Plan: `specs/011-ontology-driven-admin-shell/plan.md`
- Tasks: `specs/011-ontology-driven-admin-shell/tasks.md`

## Issue contract

- [x] Linked execution issue includes Objective, Deliverables, Acceptance Criteria, Dependencies, and References.
- [x] Scope boundary for this PR is explicit and matches the issue deliverables.
- execution issue: `#133`
- scope boundary: reusable FAB and shared action-slot workflow behavior on top of the delivered shell and descriptor-resolution contracts

## Commit contract

- [x] Branch name uses the repository's Git-safe Conventional Commit slug format.
- [x] Branch commits use Conventional Commit subjects.
- [x] Final integration path for this work is auto-squash after green checks.
- [x] No unrelated refactors, drive-by fixes, or broad rename-only churn are mixed into this PR.

## Handoff contract

- [x] Changed files and risk notes are captured in PR description.
- [x] Done/blocker state is explicit (no implicit follow-up later gaps).
- [x] Maintainers can see the primary files or behaviors to inspect first.
- inspect first: `src/core/navigation.py`, `src/lims/views.py`, `src/lims/templates/lims/receiving.html`, `src/lims/templates/lims/task_inbox.html`
- risk notes: this PR intentionally consumes the existing descriptor pipeline instead of reopening shell ownership or navigation-registry scope; the new shared action-slot path is currently proven on receiving and task inbox surfaces only
- done state: local targeted tests and full merge gate passed

## Documentation chunk

- [ ] This docs PR is a meaningful batch (target: 3+ docs files when docs-only).
- [ ] Chunk selected: Platform core / Execution modules / Security & ops / Governance domains.
- [ ] Roadmap and README links are updated together when new design docs are introduced.
- [ ] Acceptance criteria and non-goals are present in each newly added design doc.
- [ ] Cross-doc references are updated so the chunk is reviewable end-to-end in one pass.
- not a docs-only PR.

## Validation

- [x] Ran tests/checks relevant to this change.
- [x] Listed the concrete commands or manual checks used for validation in the PR body.
- `cd /home/jmduda/KodeX.2026/mtafiti/src && ../.venv/bin/python -m pytest tests/test_shell_navigation.py -q`
- `cd /home/jmduda/KodeX.2026/mtafiti/src && ../.venv/bin/python -m pytest tests/test_lims_ui.py -q -k 'receiving_operation_page_derives_fab_from_primary_action or reference_operation_page_suppresses_fab_without_changing_cards or receiving_and_task_inbox_pages_render_shared_action_slot_behavior'`
- `cd /home/jmduda/KodeX.2026/mtafiti/src && ../.venv/bin/python -m pytest tests/test_lims_ui.py -q`
- `cd /home/jmduda/KodeX.2026/mtafiti && bash .github/scripts/local_fast_feedback.sh --full-gate`
- full gate result: `299 passed, 2 deselected`
